### PR TITLE
[Feat] 랜딩 페이지 시작 화면 제작

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,9 +24,12 @@
   },
   "dependencies": {
     "clsx": "^2.1.1",
+    "framer-motion": "^12.38.0",
     "next": "16.2.4",
     "react": "19.2.4",
     "react-dom": "19.2.4",
+    "react-router": "^7.14.2",
+    "tailwind-merge": "^3.5.0",
     "zod": "^4.3.6",
     "zustand": "^5.0.12"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      framer-motion:
+        specifier: ^12.38.0
+        version: 12.38.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next:
         specifier: 16.2.4
         version: 16.2.4(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -20,6 +23,12 @@ importers:
       react-dom:
         specifier: 19.2.4
         version: 19.2.4(react@19.2.4)
+      react-router:
+        specifier: ^7.14.2
+        version: 7.14.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      tailwind-merge:
+        specifier: ^3.5.0
+        version: 3.5.0
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -909,6 +918,10 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -1204,6 +1217,20 @@ packages:
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
+
+  framer-motion@12.38.0:
+    resolution: {integrity: sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
@@ -1626,6 +1653,12 @@ packages:
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
+  motion-dom@12.38.0:
+    resolution: {integrity: sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA==}
+
+  motion-utils@12.36.0:
+    resolution: {integrity: sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg==}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -1842,6 +1875,16 @@ packages:
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
+  react-router@7.14.2:
+    resolution: {integrity: sha512-yCqNne6I8IB6rVCH7XUvlBK7/QKyqypBFGv+8dj4QBFJiiRX+FG7/nkdAvGElyvVZ/HQP5N19wzteuTARXi5Gw==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+
   react@19.2.4:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
     engines: {node: '>=0.10.0'}
@@ -1903,6 +1946,9 @@ packages:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
     engines: {node: '>=10'}
     hasBin: true
+
+  set-cookie-parser@2.7.2:
+    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -2034,6 +2080,9 @@ packages:
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+
+  tailwind-merge@3.5.0:
+    resolution: {integrity: sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==}
 
   tailwindcss@4.2.4:
     resolution: {integrity: sha512-HhKppgO81FQof5m6TEnuBWCZGgfRAWbaeOaGT00KOy/Pf/j6oUihdvBpA7ltCeAvZpFhW3j0PTclkxsd4IXYDA==}
@@ -2970,6 +3019,8 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
+  cookie@1.1.1: {}
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -3407,6 +3458,15 @@ snapshots:
     dependencies:
       is-callable: 1.2.7
 
+  framer-motion@12.38.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      motion-dom: 12.38.0
+      motion-utils: 12.36.0
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
   function-bind@1.1.2: {}
 
   function.prototype.name@1.1.8:
@@ -3809,6 +3869,12 @@ snapshots:
 
   minimist@1.2.8: {}
 
+  motion-dom@12.38.0:
+    dependencies:
+      motion-utils: 12.36.0
+
+  motion-utils@12.36.0: {}
+
   ms@2.1.3: {}
 
   nanoid@3.3.11: {}
@@ -3974,6 +4040,14 @@ snapshots:
 
   react-is@16.13.1: {}
 
+  react-router@7.14.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      cookie: 1.1.1
+      react: 19.2.4
+      set-cookie-parser: 2.7.2
+    optionalDependencies:
+      react-dom: 19.2.4(react@19.2.4)
+
   react@19.2.4: {}
 
   reflect.getprototypeof@1.0.10:
@@ -4046,6 +4120,8 @@ snapshots:
   semver@6.3.1: {}
 
   semver@7.7.4: {}
+
+  set-cookie-parser@2.7.2: {}
 
   set-function-length@1.2.2:
     dependencies:
@@ -4239,6 +4315,8 @@ snapshots:
       has-flag: 4.0.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  tailwind-merge@3.5.0: {}
 
   tailwindcss@4.2.4: {}
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,1 +1,19 @@
 @import 'tailwindcss';
+@keyframes scanSweep {
+  0% {
+    transform: translateY(-120%);
+    opacity: 0;
+  }
+  10% {
+    opacity: 1;
+  }
+  100% {
+    transform: translateY(420%);
+    opacity: 0;
+  }
+}
+
+.scan-sweep {
+  background: linear-gradient(to bottom, transparent 0%, rgba(34, 211, 238, 0.2) 50%, transparent 100%);
+  animation: scanSweep 3s linear infinite;
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,15 @@
+import NicknameStep from '@/components/start/NicknameStep';
+
 export default function HomePage() {
   return (
-    <main className="mx-auto max-w-5xl px-4 py-8">
-      <h1 className="text-3xl font-bold">Welcome</h1>
+    <main className="relative min-h-screen overflow-hidden bg-[linear-gradient(to_bottom,#ef4444_0%,#dc2626_44%,#f8fafc_44%,#f8fafc_48%)] text-white">
+      <div className="border-10px pointer-events-none absolute top-[44%] left-1/2 h-28 w-28 -translate-x-1/2 -translate-y-1/2 rounded-full bg-black shadow-[0_0_0_6px_rgba(248,250,252,0.45)]">
+        <div className="absolute inset-1/2 h-10 w-10 -translate-x-1/2 -translate-y-1/2 rounded-full border-[6px] bg-white" />
+      </div>
+
+      <div className="relative z-10 mx-auto flex min-h-screen w-full max-w-6xl items-center justify-center px-4 py-10">
+        <NicknameStep />
+      </div>
     </main>
   );
 }

--- a/src/components/start/NicknameStep.tsx
+++ b/src/components/start/NicknameStep.tsx
@@ -1,0 +1,157 @@
+'use client';
+
+import { hasTrainer } from '@/utils/storage';
+import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
+import { motion } from 'framer-motion';
+import { z } from 'zod';
+
+// zod schema
+const nicknameSchema = z
+  .string()
+  .trim()
+  .min(1, '닉네임을 입력해주세요')
+  .min(2, '닉네임은 2자 이상이어야 합니다')
+  .max(12, '닉네임은 12자 이하여야 합니다')
+  .regex(/^[가-힣a-zA-Z0-9]+$/, '한글, 영문, 숫자만 사용할 수 있습니다.');
+
+export default function NicknameStep() {
+  const [nickname, setNickname] = useState('');
+  const [error, setError] = useState('');
+  const router = useRouter();
+
+  useEffect(() => {
+    // 이미 트레이너가 있다면
+    if (hasTrainer()) {
+      router.push('/home');
+    }
+  }, [router]);
+
+  const handleSubmit = () => {
+    const result = nicknameSchema.safeParse(nickname);
+    if (!result.success) {
+      setError(result.error.issues[0].message);
+      return;
+    }
+    setError('');
+    console.log('유효한 닉네임 ', result.data);
+  };
+
+  return (
+    <section className="flex w-full max-w-md flex-col items-center">
+      {/* 타이틀 */}
+      <div className="mb-10 text-center">
+        <h1 className="text-5xl font-extrabold tracking-[0.18em] text-yellow-300 drop-shadow-[0_0_18px_rgba(253,224,71,0.35)] sm:text-6xl">
+          PODECK
+        </h1>
+        <p className="mt-2 text-sm tracking-[0.35em] text-blue-200 uppercase">choose your starter</p>
+
+        {/* 스타터 색 힌트 */}
+        <div className="mt-4 flex justify-center gap-3">
+          <div className="h-3 w-3 rounded-full bg-green-400 shadow-[0_0_10px_rgba(74,222,128,0.9)]" />
+          <div className="h-3 w-3 rounded-full bg-orange-400 shadow-[0_0_10px_rgba(251,146,60,0.9)]" />
+          <div className="h-3 w-3 rounded-full bg-sky-400 shadow-[0_0_10px_rgba(56,189,248,0.9)]" />
+        </div>
+      </div>
+
+      {/* 카드 */}
+      <motion.div
+        initial={{ opacity: 0, y: 40 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.6 }}
+        className="relative w-full overflow-hidden rounded-[28px] rounded-tr-[65px] rounded-bl-[65px] border border-blue-300/30 bg-[#11193f]/70 p-6 shadow-[0_0_40px_rgba(0,180,255,0.12)] backdrop-blur-md"
+      >
+        {/* CRT 라인 */}
+        <div
+          className="pointer-events-none absolute inset-0 opacity-10"
+          style={{
+            backgroundImage:
+              'repeating-linear-gradient(0deg, transparent, transparent 2px, rgba(34,211,238,0.12) 2px, rgba(34,211,238,0.12) 4px)',
+          }}
+        />
+
+        {/* 포켓볼 장식 */}
+        <div className="pointer-events-none absolute inset-0 opacity-10">
+          <div className="absolute top-1/2 left-1/2 h-52 w-52 -translate-x-1/2 -translate-y-1/2 rounded-full border-2 border-white/20" />
+          <div className="absolute top-1/2 left-0 h-0.5 w-full -translate-y-1/2 bg-white/15" />
+          <div className="absolute top-1/2 left-1/2 h-7 w-7 -translate-x-1/2 -translate-y-1/2 rounded-full border-2 border-white/30 bg-white/10" />
+        </div>
+
+        {/* 스캔 바 */}
+        <div className="pointer-events-none absolute inset-0 overflow-hidden">
+          <div className="scan-sweep absolute right-0 left-0 h-16" />
+        </div>
+
+        <div className="relative z-10">
+          <p className="mb-4 text-sm leading-6 text-slate-300">
+            트레이너 이름을 등록하고 <br />
+            당신만의 스타팅 포켓몬과 모험을 시작하세요!
+          </p>
+
+          <label className="mb-2 block text-sm font-medium text-slate-200">닉네임</label>
+
+          <input
+            type="text"
+            value={nickname}
+            onChange={(e) => {
+              setNickname(e.target.value);
+              if (error) setError('');
+            }}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') handleSubmit();
+            }}
+            placeholder="트레이너 이름을 입력하세요"
+            maxLength={12}
+            className="h-12 w-full rounded-xl border border-slate-500/40 bg-slate-100 px-4 text-sm text-slate-900 transition outline-none focus:border-yellow-300"
+          />
+          {/* 에러 */}
+          <div className="mt-2 h-5">
+            {error && (
+              <motion.p
+                initial={{ opacity: 0, y: -5 }}
+                animate={{ opacity: 1, y: 0 }}
+                className="text-sm font-medium text-rose-400"
+              >
+                {error}
+              </motion.p>
+            )}
+          </div>
+          <motion.button
+            whileTap={{ scale: 0.95 }}
+            whileHover={{ scale: 1.03 }}
+            type="button"
+            onClick={handleSubmit}
+            disabled={!nickname.trim()}
+            className="mt-4 h-12 w-full rounded-xl bg-linear-to-r from-yellow-300 via-amber-300 to-orange-300 text-sm font-bold text-slate-900 transition disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            모험 시작하기
+          </motion.button>
+        </div>
+      </motion.div>
+
+      <motion.div
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ delay: 0.8, duration: 1 }}
+        className="relative z-10 mt-8 flex justify-center gap-2"
+      >
+        {[...Array(4)].map((_, i) => (
+          <motion.div
+            key={i}
+            animate={{
+              opacity: [0.35, 1, 0.35],
+              scale: [0.8, 1.35, 0.8],
+            }}
+            transition={{
+              duration: 1.2,
+              repeat: Infinity,
+              delay: i * 0.25,
+              ease: 'easeInOut',
+            }}
+            className="h-2.5 w-2.5 rounded-full bg-linear-to-r from-yellow-200 to-red-300 shadow-[0_0_12px_rgba(103,232,249,0.9)]"
+          />
+        ))}
+      </motion.div>
+    </section>
+  );
+}

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,0 +1,23 @@
+export interface TrainerData {
+  nickname: string;
+  selectedPokemon: number | null; // pokemon id
+  // 더 추가 예정
+}
+
+const STORAGE_KEY = 'pokemon_trainer_data';
+
+function isBrowser() {
+  return typeof window !== 'undefined';
+}
+
+export function getTrainerData(): TrainerData | null {
+  if (!isBrowser()) return null;
+  const stored = localStorage.getItem(STORAGE_KEY);
+  if (!stored) return null;
+  return JSON.parse(stored);
+}
+
+export function hasTrainer(): boolean {
+  const data = getTrainerData();
+  return !!(data?.nickname && data?.selectedPokemon !== null);
+}


### PR DESCRIPTION
# Pull Request

## 🎯 작업 내용
닉네임 입력 화면 및 포켓몬 컨셉 초기 UI 구현

## 📌 작업 배경
포켓몬 프로젝트 시작 단계로 트레이너 이름 입력 기능 필요

## 🔨 구현 내용

#### Added (추가)
- NicknameStep 컴포넌트
- zod 유효성 검사
- framer-motion 애니메이션
- 포켓몬 스타일 UI
- 포켓볼 패턴 배경
- localStorage 저장 로직

#### Changed (변경)
- page.tsx 구조 수정

#### Fixed (수정)
- 없음

## 🧪 테스트
- [x] 로컬 테스트 완료
- [x] Enter 입력 동작 확인
- [x] 유효성 검사 확인

## 💬 리뷰 요청사항
- UI 흐름 자연스러운지
- 구조 괜찮은지

## 🔗 관련 링크
- Closes #3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * 닉네임 등록 단계 추가 - 앱 시작 시 사용자 닉네임 입력 필요
  * 닉네임 유효성 검사 - 2-12자 범위, 한글/영문/숫자만 허용
  * 트레이너 데이터 저장 - 닉네임 및 선택 정보 자동 보존

* **스타일**
  * 애니메이션 효과 추가 - 부드러운 UI 전환
  * 홈페이지 디자인 개선 - 그래디언트 배경 및 시각 요소 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->