### PR TITLE
[Feat] battle result pages 제작

### DIFF
--- a/src/app/(main)/(start)/build-deck/_components/StarterPokemonCard.tsx
+++ b/src/app/(main)/(start)/build-deck/_components/StarterPokemonCard.tsx
@@ -30,7 +30,7 @@ export default function StarterPokemonCard({
       <button
         type="button"
         onClick={() => onOpenDetail(pokemon.dexId)}
-        className="absolute top-6 left-6 z-20 cursor-grab rounded-full bg-[#EDEDED] px-3 py-1 text-xs font-bold text-[#999999]"
+        className="absolute top-6 left-6 z-20 cursor-grab rounded-full bg-[#EDEDED] px-3 py-1 text-xs font-bold text-[var(--color-base-1)]"
       >
         상세정보
       </button>
@@ -47,7 +47,7 @@ export default function StarterPokemonCard({
         {pokemon.types.map((type) => (
           <span
             key={type}
-            className={`flex items-center gap-1 rounded-full px-3 py-1 text-xs font-bold text-white ${
+            className={`flex items-center gap-1 rounded-full px-3 py-1 text-xs font-bold text-[var(--color-base-3)] ${
               typeColorMap[type] ?? 'bg-gray-400'
             }`}
           >

--- a/src/app/(main)/(start)/loading/LoadingBackground.tsx
+++ b/src/app/(main)/(start)/loading/LoadingBackground.tsx
@@ -6,7 +6,7 @@ type LoadingBackgroundProps = {
 
 export default function LoadingBackground({ children }: LoadingBackgroundProps) {
   return (
-    <main className="fixed inset-0 z-50 flex min-h-screen items-center justify-center overflow-hidden bg-white px-4">
+    <main className="fixed inset-0 z-50 flex min-h-screen items-center justify-center overflow-hidden bg-[var(--color-base-3)] px-4">
       <div
         aria-hidden="true"
         className="pointer-events-none absolute inset-0 opacity-2.5"

--- a/src/app/(main)/battle/lose/page.tsx
+++ b/src/app/(main)/battle/lose/page.tsx
@@ -1,0 +1,5 @@
+import BattleLosePage from '@/features/battle/_components/BattleLosePage';
+
+export default function Page() {
+  return <BattleLosePage />;
+}

--- a/src/app/(main)/battle/win/page.tsx
+++ b/src/app/(main)/battle/win/page.tsx
@@ -1,0 +1,5 @@
+import BattleWinPage from '@/features/battle/_components/BattleWinPage';
+
+export default function Page() {
+  return <BattleWinPage />;
+}

--- a/src/app/(main)/home/page.tsx
+++ b/src/app/(main)/home/page.tsx
@@ -4,7 +4,7 @@ import { storageKeys } from '@/app/(main)/(start)/_constants/key';
 import type { TrainerData } from '@/app/(main)/(start)/_types/trainer';
 import HomeActionCards from '@/app/(main)/home/_components/HomeActionCards';
 import HomeBanner from '@/app/(main)/home/_components/HomeBanner';
-import HomeHeader from '@/app/(main)/home/_components/HomeHeader';
+import HomeHeader from '@/shared/components/HomeHeader';
 import TrainerStatusBar from '@/app/(main)/home/_components/TrainerStatusBar';
 import { useRouter } from 'next/navigation';
 import { useEffect, useMemo, useSyncExternalStore } from 'react';
@@ -68,7 +68,7 @@ export default function HomePage() {
   const selectedPokemonCount = parsedTrainerData.selectedPokemons?.length ?? 0;
 
   return (
-    <main className="min-h-dvh overflow-x-hidden bg-[#FFFFFF] text-[#999999]">
+    <main className="min-h-dvh overflow-x-hidden bg-[var(--color-base-3)] text-[var(--color-base-1)]">
       <HomeHeader />
       <div className="mx-auto flex w-full max-w-6xl flex-col px-4 pt-14 pb-8">
         <HomeBanner />

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -85,3 +85,7 @@
   animation: slow-spin 18s linear infinite;
   transform-origin: center;
 }
+
+body {
+  font-family: 'Roboto', sans-serif;
+}

--- a/src/features/battle/_components/BattleLosePage.tsx
+++ b/src/features/battle/_components/BattleLosePage.tsx
@@ -1,0 +1,51 @@
+import HomeHeader from '@/shared/components/HomeHeader';
+import SilhouetteBackground from '@/shared/components/SilhouetteBackground';
+import Link from 'next/link';
+
+export default function BattleLosePage() {
+  return (
+    <main className="relative min-h-screen overflow-hidden bg-gradient-to-b from-[#F9F9F9] to-[#E1E1E1]">
+      <HomeHeader />
+      <SilhouetteBackground
+        className="right-[-420px] bottom-[-450px] rotate-45 opacity-10 sm:right-[-300px] sm:bottom-[-400px]"
+        imageClassName="h-[900px] w-[900px] sm:h-[1150px] sm:w-[1150px]"
+      />
+      <section className="relative z-10 flex min-h-[calc(100vh-72px)] items-center justify-center px-4">
+        <div className="relative w-full max-w-[520px] rounded-[20px] bg-[var(--color-base-3)] px-10 py-12 text-center shadow-[0_16px_40px_rgba(0,0,0,0.12)]">
+          <h1 className="mt-4 font-['NeoDunggeunmo'] text-5xl font-extrabold text-[var(--color-base-1)]">패배...</h1>
+          {/* 해당 층수는 더미 데이터라 수정이 필요합니다! */}
+          <p className="mt-4 text-sm font-medium text-[var(--color-base-1)]">10층에서 쓰러졌습니다</p>
+
+          <div className="mt-8 rounded-[10px] border border-[#E2DDD7] bg-[var(--color-base-3)] px-5 py-4 text-left">
+            <p className="text-center text-sm font-bold text-[var(--color-base-1)]">다시 도전하시겠습니까?</p>
+          </div>
+
+          {/* 밑에 들어가는 턴, 포켓못, 라이프도 더미 데이터기 때문에 수정 필요*/}
+          <div className="mt-6 flex items-center justify-center gap-6 text-xs font-medium text-[var(--color-base-1)]">
+            <span>사용 턴: 5 </span>
+            <span className="h-3 w-px bg-black/20" />
+            <span>남은 포켓몬: 5/6</span>
+            <span className="h-3 w-px bg-black/20" />
+            <span>남은 라이프: 3/4</span>
+          </div>
+
+          <div className="mt-8 flex justify-center gap-3">
+            <Link
+              href="/battle"
+              className="flex h-11 min-w-[120px] items-center justify-center rounded-[10px] bg-[var(--color-base-0)] px-5 font-['NeoDunggeunmo'] text-sm font-bold text-[var(--color-base-3)]"
+            >
+              재도전
+            </Link>
+            {/* 다음 층 href 주소 수정 필요! */}
+            <Link
+              href="/home"
+              className="flex h-11 min-w-[96px] items-center justify-center rounded-[10px] border border-black/10 bg-[var(--color-base-3)] px-5 font-['NeoDunggeunmo'] text-sm font-bold text-[var(--color-base-0)]"
+            >
+              홈으로
+            </Link>
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/src/features/battle/_components/BattleWinPage.tsx
+++ b/src/features/battle/_components/BattleWinPage.tsx
@@ -1,0 +1,55 @@
+import HomeHeader from '@/shared/components/HomeHeader';
+import SilhouetteBackground from '@/shared/components/SilhouetteBackground';
+import Link from 'next/link';
+
+export default function BattleWinPage() {
+  return (
+    <main className="relative min-h-screen overflow-hidden bg-gradient-to-b from-[#F9F9F9] to-[#E1E1E1]">
+      <HomeHeader />
+      <SilhouetteBackground
+        className="right-[-420px] bottom-[-450px] rotate-45 opacity-20 sm:right-[-370px] sm:bottom-[-500px]"
+        imageClassName="h-[1200px] w-[1200px] sm:h-[1300px] sm:w-[1300px]"
+      />
+
+      <section className="relative z-10 flex min-h-[calc(100vh-72px)] items-center justify-center px-4">
+        <div className="relative w-full max-w-[520px] rounded-[20px] bg-[var(--color-base-3)] px-10 py-12 text-center shadow-[0_16px_40px_rgba(0,0,0,0.12)]">
+          <h1 className="mt-4 font-['NeoDunggeunmo'] text-5xl font-extrabold text-[var(--color-base-0)]">승리!</h1>
+          {/* 해당 층수는 더미 데이터라 수정이 필요합니다! */}
+          <p className="mt-4 text-sm font-medium text-[var(--color-base-1)]">10층을 클리어했습니다!</p>
+
+          <div className="mt-8 rounded-[10px] border border-[#E2DDD7] bg-[#F4F1EC] px-5 py-4 text-left">
+            <p className="text-sm font-bold text-[var(--color-base-1)]">획득 보상</p>
+            <ul className="mt-3 space-y-2 text-sm font-medium text-[var(--color-base-0)]">
+              <li>💳 카드팩 +1개</li>
+            </ul>
+          </div>
+
+          {/* 밑에 들어가는 턴, 포켓못, 라이프도 더미 데이터기 때문에 수정 필요*/}
+          <div className="mt-6 flex items-center justify-center gap-6 text-xs font-medium text-[var(--color-base-1)]">
+            <span>사용 턴: 5 </span>
+            <span className="h-3 w-px bg-black/20" />
+            <span>남은 포켓몬: 5/6</span>
+            <span className="h-3 w-px bg-black/20" />
+            <span>남은 라이프: 3/4</span>
+          </div>
+
+          <div className="mt-8 flex justify-center gap-3">
+            <Link
+              href="/battle"
+              className="flex h-11 min-w-[120px] items-center justify-center rounded-[10px] bg-[var(--color-base-0)] px-5 font-['NeoDunggeunmo'] text-sm font-bold text-[var(--color-base-3)]"
+            >
+              다음 층으로
+            </Link>
+            {/* 다음 층 href 주소 수정 필요! */}
+            <Link
+              href="/home"
+              className="flex h-11 min-w-[96px] items-center justify-center rounded-[10px] border border-black/10 bg-[var(--color-base-3)] px-5 font-['NeoDunggeunmo'] text-sm font-bold text-[var(--color-base-0)]"
+            >
+              홈으로
+            </Link>
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/src/shared/components/HomeHeader.tsx
+++ b/src/shared/components/HomeHeader.tsx
@@ -1,7 +1,7 @@
 import Image from 'next/image';
 import Link from 'next/link';
 
-import { homeNavItems } from '../_constants/home';
+import { homeNavItems } from '@/app/(main)/home/_constants/home';
 
 export default function HomeHeader() {
   return (
@@ -27,7 +27,9 @@ export default function HomeHeader() {
                 key={item.id}
                 href={item.href}
                 className={`flex h-12 min-w-[112px] items-center justify-center gap-2 rounded-2xl px-5 text-base font-semibold transition ${
-                  isActive ? 'bg-[#FFFFFF] text-[#999999]' : 'text-[#9999999] hover:bg-[#F1F1F1] hover:text-[#999999]'
+                  isActive
+                    ? 'bg-[var(--color-base-3)] text-[var(--color-base-1)]'
+                    : 'text-[var(--color-base-1)] hover:bg-[var(--color-base-2)] hover:text-[var(--color-base-1)]'
                 }`}
               >
                 <Icon aria-hidden="true" className="text-xl" />


### PR DESCRIPTION
# Pull Request

## 🎯 작업 내용

<!-- 무엇을 했는지 한 줄로 요약 -->
배틀 승리/패배 결과 페이지 UI를 추가했습니다

## 📌 작업 배경

<!-- 왜 이 작업이 필요했는지 -->
배틀 종료 후 승리 또는 패배 상태에 따라 사용자에게 결과 화면을 제공하기 위해 작업했습니다

## 🔨 구현 내용

<!-- 주요 변경사항을 간략히 나열 -->


#### Added (추가)
- `/battle/win` 승리 결과 페이지 추가
- `/battle/lose` 패배 결과 페이지 추가
- 배틀 결과 페이지 UI 컴포넌트 추가


#### Changed (변경)

- `HomeHeader`를 배틀 결과 페이지에서도 재사용할 수 있도록 공용 컴포넌트로 이동
- 일부 하드코딩 색상 값을 디자인 토큰 기준으로 정리
- 기본 폰트 스타일 적용


#### Fixed (수정)

- 

## 📸 결과물

<!-- 스크린샷 또는 동작 화면 -->
 승리 시 페이지
<img width="1485" height="862" alt="스크린샷 2026-05-12 오후 4 42 58" src="https://github.com/user-attachments/assets/5cb2baee-78b1-4947-9c55-ee91bf3a160f" />
 패배 시 페이지
<img width="1494" height="862" alt="스크린샷 2026-05-12 오후 4 43 44" src="https://github.com/user-attachments/assets/faa38a01-5376-4d3c-8f0b-05feb8139ded" />


## 🧪 테스트

<!-- 어떻게 테스트했는지 -->

- [X] `/battle/win` 페이지 렌더링 확인
- [X] `/battle/lose` 페이지 렌더링 확인
- [X] `pnpm lint` 통과
- [X] `pnpm build` 통과

## 💬 리뷰 요청사항

<!-- 특히 봐주셨으면 하는 부분 -->

- UI만 담당한 것이기 때문에 실제  데이터가 들어가야할 부분들은 제가 주석으로 달아놓았습니다. 혹여나 빠트린 부분이 있다면 말씀해주세요!

## 🔗 관련 링크

<!-- 이슈, 문서, 디자인 등 -->

- Closes #18


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 기술 변경사항 요약

### 라우팅 추가
- `/battle/win` 및 `/battle/lose` 라우트 추가
- `src/app/(main)/battle/win/page.tsx` 및 `src/app/(main)/battle/lose/page.tsx` 생성

### 배틀 결과 UI 컴포넌트 구현

**BattleWinPage** (`src/features/battle/_components/BattleWinPage.tsx`)
- 승리 화면 레이아웃 (승리!!, 클리어 메시지, 보상 섹션)
- 게임 통계 표시 영역 (사용 턴, 남은 포켓몬, 남은 라이프) - 현재 더미 데이터
- 네비게이션 링크: "다음 층으로" (`/battle`), "홈으로" (`/home`)

**BattleLosePage** (`src/features/battle/_components/BattleLosePage.tsx`)
- 패배 화면 레이아웃 (패배..., 패배 메시지, 재도전 여부 확인)
- 게임 통계 표시 영역 - 현재 더미 데이터
- 네비게이션 링크: "재도전" (`/battle`), "홈으로" (`/home`)

### 공유 컴포넌트 리팩토링
- `HomeHeader` 컴포넌트를 `src/app/(main)/home/_components/` 에서 `src/shared/components/` 로 이동
- 임포트 경로 업데이트: `src/app/(main)/home/page.tsx`에서 `@/shared/components/HomeHeader` 참조로 변경
- `HomeHeader` 내부: 상대 경로 임포트를 alias 기반 경로(`@/app/(main)/home/_constants/home`)로 변경

### 디자인 토큰 적용 (CSS 변수화)
다음 파일들에서 하드코딩된 색상 값을 CSS 변수로 대체:

- **StarterPokemonCard.tsx**: `text-white` → `text-[var(--color-base-3)]`, 16진수 색상 → `text-[var(--color-base-1)]`
- **LoadingBackground.tsx**: `bg-white` → `bg-[var(--color-base-3)]`
- **home/page.tsx**: `bg-[#FFFFFF]` → `bg-[var(--color-base-3)]`, `text-[#999999]` → `text-[var(--color-base-1)]`
- **HomeHeader.tsx**: 활성/비활성 네비게이션 링크 스타일링을 16진수 색상에서 CSS 커스텀 프로퍼티(`--color-base-1/2/3`)로 변경

### 기본 폰트 스타일 적용
- **globals.css**: `body` 요소에 `font-family: 'Roboto', sans-serif` 추가

### 주요 특징
- 모든 배틀 결과 컴포넌트는 상태 저장 없이 UI만 렌더링 (더미 데이터 사용)
- 코드 내 주석으로 실제 데이터 연동이 필요한 영역 명시
- Next.js 라우팅 구조 활용하여 모달이 아닌 전체 페이지로 구현
- 기존 UI 컴포넌트(`HomeHeader`, `SilhouetteBackground`) 재사용

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PODECK/FE/pull/18)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->