### PR TITLE
[Feat] mydeck page 제작

### DIFF
--- a/src/app/(main)/(start)/_types/trainer.ts
+++ b/src/app/(main)/(start)/_types/trainer.ts
@@ -6,4 +6,5 @@ export interface TrainerData {
   nickname: string;
   createdAt: string;
   selectedPokemons?: SelectedPokemon[];
+  activeDeckDexIds?: number[]; // 내 덱 편성에서 쓰일 필드
 }

--- a/src/app/(main)/home/_components/HomeActionCards.tsx
+++ b/src/app/(main)/home/_components/HomeActionCards.tsx
@@ -3,14 +3,19 @@ import HomeActionCard from '@/app/(main)/home/_components/HomeActionCard';
 
 interface HomeActionCardsProps {
   selectedPokemonCount: number;
+  totalPokemonCount: number;
 }
 
-export default function HomeActionCards({ selectedPokemonCount }: HomeActionCardsProps) {
+export default function HomeActionCards({ selectedPokemonCount, totalPokemonCount }: HomeActionCardsProps) {
   return (
     <section className="mt-8 grid grid-cols-1 gap-6 md:grid-cols-3">
       {homeActionCards.map((card) => {
-        const description = card.id === 'deck' ? `보유 포켓몬 ${selectedPokemonCount} 마리` : card.description;
-
+        const description =
+          card.id === 'mydeck'
+            ? `보유 포켓몬 ${selectedPokemonCount} 마리`
+            : card.id === 'pokedex'
+              ? `발견한 포켓몬 ${selectedPokemonCount}/${totalPokemonCount}`
+              : card.description;
         return (
           <HomeActionCard
             key={card.id}

--- a/src/app/(main)/home/page.tsx
+++ b/src/app/(main)/home/page.tsx
@@ -8,6 +8,7 @@ import HomeHeader from '@/shared/components/HomeHeader';
 import TrainerStatusBar from '@/app/(main)/home/_components/TrainerStatusBar';
 import { useRouter } from 'next/navigation';
 import { useEffect, useMemo, useSyncExternalStore } from 'react';
+import pokemonData from '../../../../data/pokemon.json';
 
 /* hydration error 방지 */
 const subscribeTrainerStorage = (onStoreChange: () => void) => {
@@ -65,7 +66,9 @@ export default function HomePage() {
 
   if (!hasValidTrainer) return null;
 
+  // 홈 화면 카드 섹션에서 보여줄 포유 포켓몬 갯수 관리 상수
   const selectedPokemonCount = parsedTrainerData.selectedPokemons?.length ?? 0;
+  const totalPokemonCount = Object.keys(pokemonData).length;
 
   return (
     <main className="min-h-dvh overflow-x-hidden bg-[var(--color-base-3)] text-[var(--color-base-1)]">
@@ -80,7 +83,7 @@ export default function HomePage() {
           battleRecord="8승 3패"
         />
 
-        <HomeActionCards selectedPokemonCount={selectedPokemonCount} />
+        <HomeActionCards selectedPokemonCount={selectedPokemonCount} totalPokemonCount={totalPokemonCount} />
       </div>
 
       <footer className="pb-6 text-center text-sm text-[#888888]">© 2026 Team 로켓단. All rights Reserved</footer>

--- a/src/app/(main)/mydeck/_components/EmptyMyDeck.tsx
+++ b/src/app/(main)/mydeck/_components/EmptyMyDeck.tsx
@@ -1,0 +1,7 @@
+export default function EmptyMyDeck() {
+  return (
+    <section className="mt-12 flex min-h-[240px] items-center justify-center rounded-lg border border-dashed border-gray-200">
+      <p className="text-sm text-gray-500">아직 보유한 포켓몬이 없습니다.</p>
+    </section>
+  );
+}

--- a/src/app/(main)/mydeck/_components/MyDeckFilterBar.tsx
+++ b/src/app/(main)/mydeck/_components/MyDeckFilterBar.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+type MyDeckFilterBarProps = {
+  pokemonCount: number;
+  searchKeyword: string;
+  onChangeSearchKeyword: (keyword: string) => void;
+  onResetSearchKeyword: () => void;
+};
+
+export default function MyDeckFilterBar({
+  pokemonCount,
+  searchKeyword,
+  onChangeSearchKeyword,
+  onResetSearchKeyword,
+}: MyDeckFilterBarProps) {
+  return (
+    <section className="mx-auto mt-4 max-w-[1150px] rounded-[20px] bg-[var(--color-base-2)]/40 p-5">
+      <div className="flex items-center gap-3">
+        <input
+          type="search"
+          value={searchKeyword}
+          onChange={(event) => onChangeSearchKeyword(event.target.value)}
+          placeholder="포켓몬 이름을 입력하세요."
+          className="h-10 flex-1 rounded-full border border-gray-200 px-4 text-sm outline-none"
+        />
+        <button
+          type="button"
+          onClick={onResetSearchKeyword}
+          className="h-10 rounded-full bg-gray-700 px-5 text-sm font-semibold text-[var(--color-base-3)]"
+        >
+          초기화
+        </button>
+
+        <p className="ml-auto text-sm text-gray-500">
+          보유 <strong className="text-[var(--color-primary)]">{pokemonCount}</strong> 마리
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/src/app/(main)/mydeck/_components/MyDeckPokemonCard.tsx
+++ b/src/app/(main)/mydeck/_components/MyDeckPokemonCard.tsx
@@ -1,0 +1,56 @@
+import type { PokemonData } from '@/shared/types';
+import { typeColorMap, typeIconMap, typeLabelMap } from '@/app/(main)/(start)/build-deck/_constants/pokemon-type';
+import Image from 'next/image';
+import { CirclePlus } from 'lucide-react';
+
+type MyDeckPokemonCardProps = {
+  pokemon: PokemonData;
+  isSelected: boolean;
+  onAddPokemon: (pokemon: PokemonData) => void;
+};
+
+export default function MyDeckPoekmonCard({ pokemon, isSelected, onAddPokemon }: MyDeckPokemonCardProps) {
+  return (
+    <article className="rounded-[20px] border border-gray-200 bg-[var(--color-base-3)] p-3 shadow-sm">
+      <div className="flex h-32 items-center justify-center rounded-[10px] bg-gray-50">
+        <Image
+          width={140}
+          height={140}
+          src={pokemon.artworkUrl}
+          alt={pokemon.koName}
+          className="h-28 w-28 object-contain"
+        />
+      </div>
+
+      <p className="mt-3 text-xs text-[var(--color-base-1)]">#{String(pokemon.dexId).padStart(5, '0')}</p>
+
+      <h3 className="text-sm font-semibold text-[var(--color-base-0)]">{pokemon.koName}</h3>
+
+      <p className="mt-1 text-xs text-[var(--color-base-1)]">{pokemon.category}</p>
+
+      {/* 타입은 검색/필터 기능에서도 재사용될 데이터라 배열 그대로 렌더링합니다. */}
+      <div className="mt-3 flex flex-wrap gap-1">
+        {pokemon.types.map((type) => (
+          <span
+            key={type}
+            className={`flex items-center gap-1 rounded-full px-3 py-1 text-[10px] font-bold text-[var(--color-base-3)] ${
+              typeColorMap[type] ?? 'bg-gray-400'
+            }`}
+          >
+            <Image src={typeIconMap[type]} alt="" width={14} height={14} />
+            {typeLabelMap[type] ?? type}
+          </span>
+        ))}
+        <button
+          type="button"
+          onClick={() => onAddPokemon(pokemon)}
+          disabled={isSelected}
+          className="ml-auto flex h-9 w-9 items-center justify-center rounded-full disabled:opacity-40"
+          aria-label={`${pokemon.koName} 덱에 추가`}
+        >
+          <CirclePlus className="h-6 w-6 text-[var(--color-base-0)]" />
+        </button>
+      </div>
+    </article>
+  );
+}

--- a/src/app/(main)/mydeck/_components/MyDeckPokemonGrid.tsx
+++ b/src/app/(main)/mydeck/_components/MyDeckPokemonGrid.tsx
@@ -1,0 +1,23 @@
+import MyDeckPoekmonCard from '@/app/(main)/mydeck/_components/MyDeckPokemonCard';
+import type { PokemonData } from '@/shared/types';
+
+type MyDeckPoekmonGridProps = {
+  pokemons: PokemonData[];
+  selectedSlotPokemonIds: Set<number>;
+  onAddPokemon: (pokemon: PokemonData) => void;
+};
+
+export default function MyDeckPokemonGrid({ pokemons, selectedSlotPokemonIds, onAddPokemon }: MyDeckPoekmonGridProps) {
+  return (
+    <section className="mx-auto mt-4 grid max-w-[1150px] grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
+      {pokemons.map((pokemon) => (
+        <MyDeckPoekmonCard
+          key={pokemon.dexId}
+          pokemon={pokemon}
+          isSelected={selectedSlotPokemonIds.has(pokemon.dexId)}
+          onAddPokemon={onAddPokemon}
+        />
+      ))}
+    </section>
+  );
+}

--- a/src/app/(main)/mydeck/_components/MydeckFormation.tsx
+++ b/src/app/(main)/mydeck/_components/MydeckFormation.tsx
@@ -1,0 +1,63 @@
+import type { PokemonData } from '@/shared/types';
+import Image from 'next/image';
+import { X } from 'lucide-react';
+
+type MyDeckFormationProps = {
+  selectedPokemons: PokemonData[];
+  onRemovePokemon: (dexId: number) => void;
+};
+
+const MAX_DECK_SIZE = 6;
+
+export default function MyDeckFormation({ selectedPokemons, onRemovePokemon }: MyDeckFormationProps) {
+  const slots = Array.from({ length: MAX_DECK_SIZE }, (_, index) => selectedPokemons[index] ?? null);
+
+  return (
+    <section className="bg-gradient-primary mx-auto mt-4 max-w-[1150px] rounded-[20px] px-6 py-5">
+      <div className="mx-auto max-w-[1200px]">
+        <div className="mb-4 flex items-center justify-between">
+          <h2 className="text-lg font-bold text-[var(--color-base-3)]">내 덱 편성</h2>
+          <p className="text-sm font-semibold text-[var(--color-base-3)]">
+            {selectedPokemons.length} / {MAX_DECK_SIZE}
+          </p>
+        </div>
+
+        <div className="grid grid-cols-6 gap-6">
+          {slots.map((pokemon, index) => (
+            <div
+              key={pokemon?.dexId ?? `empty-${index}`}
+              className="relative flex aspect-[3/4] h-[220px] w-full items-center justify-center rounded-lg border border-[var(--color-base-3)]/20 bg-[var(--color-base-3)]/10"
+            >
+              {pokemon ? (
+                <>
+                  <Image
+                    src={pokemon.artworkUrl}
+                    alt={pokemon.koName}
+                    width={140}
+                    height={140}
+                    className="h-[110px] w-[110px] object-contain"
+                  />
+
+                  <button
+                    type="button"
+                    onClick={() => onRemovePokemon(pokemon.dexId)}
+                    className="absolute top-1 right-1 flex h-7 w-7 items-center justify-center rounded-full bg-[var(--color-base-0)]/50 text-[var(--color-base-3)]"
+                    aria-label={`${pokemon.koName} 덱에서 제거`}
+                  >
+                    <X className="h-4 w-4" />
+                  </button>
+
+                  <span className="absolute bottom-2 max-w-[80%] truncate text-sm font-semibold text-[var(--color-base-3)]">
+                    {pokemon.koName}
+                  </span>
+                </>
+              ) : (
+                <span className="text-3xl font-bold text-[var(--color-base-3)]/60">+</span>
+              )}
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/app/(main)/mydeck/_hooks/useMyDeckPokemons.ts
+++ b/src/app/(main)/mydeck/_hooks/useMyDeckPokemons.ts
@@ -1,0 +1,57 @@
+'use client';
+
+import { storageKeys } from '@/app/(main)/(start)/_constants/key';
+import type { TrainerData } from '@/app/(main)/(start)/_types/trainer';
+import type { PokemonData } from '@/shared/types';
+import { useCallback, useSyncExternalStore, useMemo } from 'react';
+import pokemonDataJson from '../../../../../data/pokemon.json';
+
+function isPokemonData(pokemon: PokemonData | undefined): pokemon is PokemonData {
+  return Boolean(pokemon);
+}
+
+const pokemonDataById = pokemonDataJson as Record<string, PokemonData>;
+
+export function useMyDeckPokemons() {
+  const subscribeTrainerData = useCallback((onStoreChange: () => void) => {
+    if (typeof window === 'undefined') return () => {};
+
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key === storageKeys.TRAINER_DATA) {
+        onStoreChange();
+      }
+    };
+
+    window.addEventListener('storage', handleStorage);
+
+    return () => {
+      window.removeEventListener('storage', handleStorage);
+    };
+  }, []);
+
+  const trainerDataJson = useSyncExternalStore(
+    subscribeTrainerData,
+    () => {
+      if (typeof window === 'undefined') return null;
+      return window.localStorage.getItem(storageKeys.TRAINER_DATA);
+    },
+    () => null,
+  ); // localstorage에서 값을 읽을 때 발생할 수 있는 무한 렌더링 방지 목적
+
+  const trainerData = useMemo(() => {
+    if (!trainerDataJson) return null;
+    return JSON.parse(trainerDataJson) as TrainerData;
+  }, [trainerDataJson]);
+
+  const pokemons = useMemo(() => {
+    const selectedPokemons = trainerData?.selectedPokemons ?? [];
+
+    //localstorage에 저장된 포켓몬 객체에선 dexId만 사용
+    return selectedPokemons.map((pokemon) => pokemonDataById[String(pokemon.dexId)]).filter(isPokemonData);
+  }, [trainerData]);
+
+  return {
+    pokemons,
+    pokemonCount: pokemons.length,
+  };
+}

--- a/src/app/(main)/mydeck/_hooks/useMyDeckPokemons.ts
+++ b/src/app/(main)/mydeck/_hooks/useMyDeckPokemons.ts
@@ -40,7 +40,13 @@ export function useMyDeckPokemons() {
 
   const trainerData = useMemo(() => {
     if (!trainerDataJson) return null;
-    return JSON.parse(trainerDataJson) as TrainerData;
+
+    try {
+      return JSON.parse(trainerDataJson) as TrainerData;
+    } catch (error) {
+      console.error('트레이너 데이터를 불러오지 못했습니다.', error);
+      return null;
+    }
   }, [trainerDataJson]);
 
   const pokemons = useMemo(() => {

--- a/src/app/(main)/mydeck/page.tsx
+++ b/src/app/(main)/mydeck/page.tsx
@@ -1,0 +1,123 @@
+'use client';
+
+import MyDeckFilterBar from '@/app/(main)/mydeck/_components/MyDeckFilterBar';
+import MyDeckPokemonGrid from '@/app/(main)/mydeck/_components/MyDeckPokemonGrid';
+import EmptyMyDeck from '@/app/(main)/mydeck/_components/EmptyMyDeck';
+import { useMyDeckPokemons } from '@/app/(main)/mydeck/_hooks/useMyDeckPokemons';
+import HomeHeader from '@/shared/components/HomeHeader';
+import { useMemo, useState, useCallback } from 'react';
+import type { PokemonData } from '@/shared/types';
+import MyDeckFormation from '@/app/(main)/mydeck/_components/MydeckFormation';
+import { storageKeys } from '@/app/(main)/(start)/_constants/key';
+import type { TrainerData } from '@/app/(main)/(start)/_types/trainer';
+
+const MAX_DECK_SIZE = 6;
+
+// localStorage에 저장된 트레이너 데이터를 안전하게 읽어옴
+// 브라우저 환경이 아니거나 JSON 파싱에 실패하면 null을 반환
+function readTrainerData() {
+  if (typeof window === 'undefined') return null;
+
+  try {
+    const rawData = window.localStorage.getItem(storageKeys.TRAINER_DATA);
+    return rawData ? (JSON.parse(rawData) as TrainerData) : null;
+  } catch {
+    return null;
+  }
+}
+
+// 저장된 트레이너 데이터에서 현재 편성된 덱의 포켓몬 dexId 목록을 가져오기
+function readActiveDeckDexIds() {
+  return readTrainerData()?.activeDeckDexIds ?? [];
+}
+
+// 현재 편성된 덱의 포켓몬 dexId 목록을 기존 트레이너 데이터에 병합해 저장
+function saveActiveDeckDexIds(dexIds: number[]) {
+  const trainerData = readTrainerData();
+  if (!trainerData) return;
+
+  window.localStorage.setItem(
+    storageKeys.TRAINER_DATA,
+    JSON.stringify({
+      ...trainerData,
+      activeDeckDexIds: dexIds,
+    }),
+  );
+}
+
+export default function MyDeckPage() {
+  const { pokemons, pokemonCount } = useMyDeckPokemons();
+  const [searchKeyword, setSearchKeyword] = useState('');
+  const [selectedPokemonDexIds, setSelectedPokemonDexIds] = useState<number[]>(readActiveDeckDexIds);
+
+  const selectedPokemons = useMemo(() => {
+    return selectedPokemonDexIds
+      .map((dexId) => pokemons.find((pokemon) => pokemon.dexId === dexId))
+      .filter((pokemon): pokemon is PokemonData => Boolean(pokemon));
+  }, [pokemons, selectedPokemonDexIds]);
+
+  const filteredPokemons = useMemo(() => {
+    const trimmedKeyword = searchKeyword.trim();
+    const lowerCaseKeyword = trimmedKeyword.toLowerCase();
+
+    if (!trimmedKeyword) return pokemons;
+
+    return pokemons.filter((pokemon) => {
+      return pokemon.koName.includes(trimmedKeyword) || pokemon.enName.toLowerCase().includes(lowerCaseKeyword);
+    });
+  }, [pokemons, searchKeyword]);
+
+  const selectedSlotPokemonIds = useMemo(() => {
+    return new Set(selectedPokemonDexIds);
+  }, [selectedPokemonDexIds]);
+
+  const handleResetSearchKeyword = () => {
+    setSearchKeyword('');
+  };
+
+  const handleAddPokemon = useCallback((pokemon: PokemonData) => {
+    setSelectedPokemonDexIds((prev) => {
+      if (prev.includes(pokemon.dexId)) return prev;
+      if (prev.length >= MAX_DECK_SIZE) return prev;
+
+      const nextDexIds = [...prev, pokemon.dexId];
+      saveActiveDeckDexIds(nextDexIds);
+
+      return nextDexIds;
+    });
+  }, []);
+
+  const handleRemovePokemon = useCallback((dexId: number) => {
+    setSelectedPokemonDexIds((prev) => {
+      const nextDexIds = prev.filter((selectedDexId) => selectedDexId !== dexId);
+      saveActiveDeckDexIds(nextDexIds);
+
+      return nextDexIds;
+    });
+  }, []);
+
+  return (
+    <main className="mx-auto w-full max-w-full">
+      <HomeHeader />
+
+      <MyDeckFormation selectedPokemons={selectedPokemons} onRemovePokemon={handleRemovePokemon} />
+
+      <MyDeckFilterBar
+        pokemonCount={pokemonCount}
+        searchKeyword={searchKeyword}
+        onChangeSearchKeyword={setSearchKeyword}
+        onResetSearchKeyword={handleResetSearchKeyword}
+      />
+
+      {pokemonCount > 0 ? (
+        <MyDeckPokemonGrid
+          pokemons={filteredPokemons}
+          selectedSlotPokemonIds={selectedSlotPokemonIds}
+          onAddPokemon={handleAddPokemon}
+        />
+      ) : (
+        <EmptyMyDeck />
+      )}
+    </main>
+  );
+}


### PR DESCRIPTION
# Pull Request

## 🎯 작업 내용

<!-- 무엇을 했는지 한 줄로 요약 -->
내 덱 관리 페이지를 추가하고, 홈 화면에서 내 덱 정보가 연결되도록 수정했습니다

## 📌 작업 배경

<!-- 왜 이 작업이 필요했는지 -->
사용자가 보유한 포켓몬을 확인하고, 배틀에 사용할 덱을 직접 편성할 수 있는 화면이 필요해 작업했습니다

## 🔨 구현 내용

<!-- 주요 변경사항을 간략히 나열 -->

#### Added (추가)

- `/mydeck` 페이지 추가
- 내 덱 편성 영역 추가
  - 최대 6마리까지 덱에 추가 가능
  - 선택한 포켓몬 제거 가능
  - 선택한 덱 정보를 `localStorage`의 trainer data에 저장
- 보유 포켓몬 목록 그리드 추가
- 포켓몬 이름 검색 기능 추가
- 내 덱이 비어 있을 때 보여줄 empty 상태 UI 추가


#### Changed (변경)

- `TrainerData` 타입에 활성 덱 포켓몬 ID 목록을 저장할 수 있는 필드 추가
- 홈 액션 카드에서 내 덱 카드의 보유 포켓몬 수 표시 조건을 `mydeck` 기준으로 수정
- 홈 페이지에서 전체 포켓몬 수 정보를 내 덱 카드에 전달하도록 수정

#### Fixed (수정)

- 홈 화면에서 보유 포켓몬 더미 데이터로 들어가있는 수치를 실제 데이터로 변경

## 📸 결과물

<!-- 스크린샷 또는 동작 화면 -->
- 내 덱 관리 페이지 
<img width="1512" height="861" alt="스크린샷 2026-05-14 오후 8 57 33" src="https://github.com/user-attachments/assets/e4ba6ff5-d7b7-42bb-9469-efdfcbb4942d" />

- 내 덱 추가
<img width="1511" height="863" alt="스크린샷 2026-05-14 오후 8 57 51" src="https://github.com/user-attachments/assets/29166e7d-5d1a-48f6-94d3-804cc5156ecb" />

- 검색 기능
<img width="1512" height="860" alt="스크린샷 2026-05-14 오후 8 58 02" src="https://github.com/user-attachments/assets/b04c3a75-0f9c-4d4d-a87a-6bdba9a7c808" />

- 홈 카드 섹션 정보 최신화
<img width="782" height="210" alt="스크린샷 2026-05-14 오후 9 41 10" src="https://github.com/user-attachments/assets/15cbf887-405c-4e2f-a00b-7ec63e716ba8" />


<!-- 어떻게 테스트했는지 -->

- [X] pnpm lint 통과
- [X] pnpm build 통과

## 💬 리뷰 요청사항

<!-- 특히 봐주셨으면 하는 부분 -->

- 추가하고 싶은 기능 같은 거 있으면 알려주세요

## 🔗 관련 링크

<!-- 이슈, 문서, 디자인 등 -->

- Closes #24
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 마이덱 페이지 추가: 최대 6개의 포켓몬을 선택하여 덱을 구성할 수 있는 기능 추가
  * 포켓몬 검색 및 필터링: 포켓몬 이름으로 검색하고 선택 상태를 확인할 수 있는 검색 바 추가
  * 덱 구성 디스플레이: 선택한 포켓몬을 시각적으로 표시하고 추가/제거 가능
  * 포켓몬 카드 UI: 타입, 분류 정보와 함께 포켓몬 상세 정보 표시

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PODECK/FE/pull/24)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->