### PR TITLE
[Feat] mydeck home update

### DIFF
--- a/src/app/(main)/home/page.tsx
+++ b/src/app/(main)/home/page.tsx
@@ -71,22 +71,20 @@ export default function HomePage() {
   const totalPokemonCount = Object.keys(pokemonData).length;
 
   return (
-    <main className="min-h-dvh overflow-x-hidden bg-[var(--color-base-3)] text-[var(--color-base-1)]">
+    <main className="flex min-h-dvh flex-col overflow-x-hidden bg-[var(--color-base-3)] text-[var(--color-base-1)]">
       <HomeHeader />
-      <div className="mx-auto flex w-full max-w-6xl flex-col px-4 pt-14 pb-8">
+      <div className="mx-auto flex w-full max-w-6xl flex-1 flex-col px-4 pt-14 pb-8">
         <HomeBanner />
-
         <TrainerStatusBar
           trainerName={parsedTrainerData.nickname}
           cardPackCount={5}
           towerProgress={12}
           battleRecord="8승 3패"
         />
-
         <HomeActionCards selectedPokemonCount={selectedPokemonCount} totalPokemonCount={totalPokemonCount} />
       </div>
 
-      <footer className="pb-6 text-center text-sm text-[#888888]">© 2026 Team 로켓단. All rights Reserved</footer>
+      <footer className="pb-6 text-center text-sm text-[#888888]">© 2026 Team 로켓단. All rights Reserved.</footer>
     </main>
   );
 }

--- a/src/app/(main)/mydeck/_components/MyDeckFilterBar.tsx
+++ b/src/app/(main)/mydeck/_components/MyDeckFilterBar.tsx
@@ -20,7 +20,8 @@ export default function MyDeckFilterBar({
           type="search"
           value={searchKeyword}
           onChange={(event) => onChangeSearchKeyword(event.target.value)}
-          placeholder="포켓몬 이름을 입력하세요."
+          onFocus={(event) => (event.currentTarget.style.borderColor = 'var(--color-primary)')}
+          placeholder="포켓몬 이름을 입력하세요"
           className="h-10 flex-1 rounded-full border border-gray-200 px-4 text-sm outline-none"
         />
         <button

--- a/src/app/(main)/mydeck/_components/MydeckFormation.tsx
+++ b/src/app/(main)/mydeck/_components/MydeckFormation.tsx
@@ -13,10 +13,10 @@ export default function MyDeckFormation({ selectedPokemons, onRemovePokemon }: M
   const slots = Array.from({ length: MAX_DECK_SIZE }, (_, index) => selectedPokemons[index] ?? null);
 
   return (
-    <section className="bg-gradient-primary mx-auto mt-4 max-w-[1150px] rounded-[20px] px-6 py-5">
+    <section className="bg-gradient-primary mx-auto mt-15 max-w-[1150px] rounded-[20px] px-6 py-5">
       <div className="mx-auto max-w-[1200px]">
         <div className="mb-4 flex items-center justify-between">
-          <h2 className="text-lg font-bold text-[var(--color-base-3)]">내 덱 편성</h2>
+          <h2 className="text-lg font-extrabold text-[var(--color-base-3)]">내 덱 편성</h2>
           <p className="text-sm font-semibold text-[var(--color-base-3)]">
             {selectedPokemons.length} / {MAX_DECK_SIZE}
           </p>
@@ -35,7 +35,7 @@ export default function MyDeckFormation({ selectedPokemons, onRemovePokemon }: M
                     alt={pokemon.koName}
                     width={140}
                     height={140}
-                    className="h-[110px] w-[110px] object-contain"
+                    className="mb-5 h-[110px] w-[110px] object-contain"
                   />
 
                   <button
@@ -47,12 +47,12 @@ export default function MyDeckFormation({ selectedPokemons, onRemovePokemon }: M
                     <X className="h-4 w-4" />
                   </button>
 
-                  <span className="absolute bottom-2 max-w-[80%] truncate text-sm font-semibold text-[var(--color-base-3)]">
+                  <span className="absolute bottom-2 max-w-[80%] truncate text-sm font-bold text-[var(--color-base-3)]">
                     {pokemon.koName}
                   </span>
                 </>
               ) : (
-                <span className="text-3xl font-bold text-[var(--color-base-3)]/60">+</span>
+                <span className="text-3xl font-bold text-[var(--color-primary)]">+</span>
               )}
             </div>
           ))}

--- a/src/app/(main)/mydeck/page.tsx
+++ b/src/app/(main)/mydeck/page.tsx
@@ -53,7 +53,6 @@ export default function MyDeckPage() {
   const [searchKeyword, setSearchKeyword] = useState('');
   const [selectedPokemonDexIds, setSelectedPokemonDexIds] = useState<number[]>(readActiveDeckDexIds);
   const [page, setPage] = useState(1);
-  // const [search, setSearch] = useState('');
 
   const selectedPokemons = useMemo(() => {
     return selectedPokemonDexIds
@@ -73,13 +72,20 @@ export default function MyDeckPage() {
   }, [pokemons, searchKeyword]);
 
   const totalPages = Math.ceil(filteredPokemons.length / ITEMS_PER_PAGE);
+  const currentPage = totalPages < 1 ? 1 : Math.min(Math.max(page, 1), totalPages);
 
   const selectedSlotPokemonIds = useMemo(() => {
     return new Set(selectedPokemonDexIds);
   }, [selectedPokemonDexIds]);
 
+  const pagedPokemons = useMemo(() => {
+    const start = (currentPage - 1) * ITEMS_PER_PAGE;
+    return filteredPokemons.slice(start, start + ITEMS_PER_PAGE);
+  }, [filteredPokemons, currentPage]);
+
   const handleResetSearchKeyword = () => {
     setSearchKeyword('');
+    setPage(1);
   };
 
   const handleAddPokemon = useCallback((pokemon: PokemonData) => {
@@ -112,13 +118,16 @@ export default function MyDeckPage() {
       <MyDeckFilterBar
         pokemonCount={pokemonCount}
         searchKeyword={searchKeyword}
-        onChangeSearchKeyword={setSearchKeyword}
+        onChangeSearchKeyword={(keyword) => {
+          setSearchKeyword(keyword);
+          setPage(1);
+        }}
         onResetSearchKeyword={handleResetSearchKeyword}
       />
 
       {pokemonCount > 0 ? (
         <MyDeckPokemonGrid
-          pokemons={filteredPokemons}
+          pokemons={pagedPokemons}
           selectedSlotPokemonIds={selectedSlotPokemonIds}
           onAddPokemon={handleAddPokemon}
         />
@@ -126,7 +135,7 @@ export default function MyDeckPage() {
         <EmptyMyDeck />
       )}
 
-      <Pagination page={page} setPage={setPage} totalPages={totalPages} />
+      <Pagination page={currentPage} setPage={setPage} totalPages={totalPages} />
     </main>
   );
 }

--- a/src/app/(main)/mydeck/page.tsx
+++ b/src/app/(main)/mydeck/page.tsx
@@ -10,8 +10,11 @@ import type { PokemonData } from '@/shared/types';
 import MyDeckFormation from '@/app/(main)/mydeck/_components/MydeckFormation';
 import { storageKeys } from '@/app/(main)/(start)/_constants/key';
 import type { TrainerData } from '@/app/(main)/(start)/_types/trainer';
+import Pagination from '@/app/(main)/pokedex/_components/Pagination';
 
 const MAX_DECK_SIZE = 6;
+
+const ITEMS_PER_PAGE = 20;
 
 // localStorage에 저장된 트레이너 데이터를 안전하게 읽어옴
 // 브라우저 환경이 아니거나 JSON 파싱에 실패하면 null을 반환
@@ -49,6 +52,8 @@ export default function MyDeckPage() {
   const { pokemons, pokemonCount } = useMyDeckPokemons();
   const [searchKeyword, setSearchKeyword] = useState('');
   const [selectedPokemonDexIds, setSelectedPokemonDexIds] = useState<number[]>(readActiveDeckDexIds);
+  const [page, setPage] = useState(1);
+  // const [search, setSearch] = useState('');
 
   const selectedPokemons = useMemo(() => {
     return selectedPokemonDexIds
@@ -66,6 +71,8 @@ export default function MyDeckPage() {
       return pokemon.koName.includes(trimmedKeyword) || pokemon.enName.toLowerCase().includes(lowerCaseKeyword);
     });
   }, [pokemons, searchKeyword]);
+
+  const totalPages = Math.ceil(filteredPokemons.length / ITEMS_PER_PAGE);
 
   const selectedSlotPokemonIds = useMemo(() => {
     return new Set(selectedPokemonDexIds);
@@ -118,6 +125,8 @@ export default function MyDeckPage() {
       ) : (
         <EmptyMyDeck />
       )}
+
+      <Pagination page={page} setPage={setPage} totalPages={totalPages} />
     </main>
   );
 }


### PR DESCRIPTION
# Pull Request

## 🎯 작업 내용

<!-- 무엇을 했는지 한 줄로 요약 -->
내 덱 관리 페이지의 UI를 조정하고 페이지네이션을 추가했습니다. 모니터에서 보이는 홈 화면 하단 여백을 줄이는 작업을 진행했습니다.

## 📌 작업 배경

<!-- 왜 이 작업이 필요했는지 -->
내 덱 관리 페이지에서 보유 포켓몬 목록이 많아질 경우 한 화면에 너무 많은 카드가 노출될 수 있어, 페이지 단위로 나누어 볼 수 있도록 개선했습니다.  
또한 내 덱 편성 영역과 검색 영역의 UI 간격 및 스타일을 조정해 화면 구성을 정리했습니다

## 🔨 구현 내용

<!-- 주요 변경사항을 간략히 나열 -->


#### Added (추가)

- 내 덱 포켓몬 목록 페이지네이션 추가
- 페이지당 표시할 포켓몬 수 상수 추가


#### Changed (변경)

- 내 덱 편성 영역 상단 여백 및 타이틀 강조 스타일 조정
- 내 덱 검색 입력창 placeholder 문구 수정
- 검색 입력창 focus 시 primary 색상으로 border 강조
- 홈 화면 레이아웃이 화면 높이를 안정적으로 채우도록 flex 구조 적용

#### Fixed (수정)

- 홈 화면 여백 제거

## 📸 결과물

<!-- 스크린샷 또는 동작 화면 -->
<img width="1124" height="356" alt="스크린샷 2026-05-15 오전 11 42 54" src="https://github.com/user-attachments/assets/e6aee721-34c6-42bb-99d6-ee04a0029461" />

## 🧪 테스트
<!-- 어떻게 테스트했는지 -->

- [X] corepack pnpm lint 통과
- [X] corepack pnpm build 통과

## 💬 리뷰 요청사항

<!-- 특히 봐주셨으면 하는 부분 -->

-

## 🔗 관련 링크

<!-- 이슈, 문서, 디자인 등 -->

- Closes #25


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 마이덱 페이지에 페이징 기능이 추가되었습니다.
  * 검색 입력에 포커스 이벤트 핸들러가 추가되어 포커스 시 테두리 색상이 변경됩니다.

* **Style**
  * 페이지 레이아웃 구조와 여백이 조정되었습니다.
  * 포켓몬 카드의 폰트 굵기, 간격, 색상 스타일이 개선되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PODECK/FE/pull/25)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->