### PR TITLE
fix(battle): 카드 렌더와 hydration 수정

### DIFF
--- a/src/features/battle/_components/BattleScreen.tsx
+++ b/src/features/battle/_components/BattleScreen.tsx
@@ -53,7 +53,8 @@ export default function BattleScreen() {
   const [skillModal, setSkillModal] = useState<SkillModalData | null>(null);
   const [pokemonSelectOpen, setPokemonSelectOpen] = useState(false);
   const [confirmQuit, setConfirmQuit] = useState(false);
-  const [pokemonList, setPokemonList] = useState<PokemonEntry[]>(createInitialPokemon);
+  const [pokemonList, setPokemonList] = useState<PokemonEntry[]>([]);
+  const [isDeckLoaded, setIsDeckLoaded] = useState(false);
   const [aiPokemon, setAiPokemon] = useState<AiPokemonStatus[]>([]);
   const [battleLogs, setBattleLogs] = useState<BattleLogEntry[]>([]);
   const [turnPhase, setTurnPhase] = useState<TurnPhase>('setup');
@@ -61,7 +62,7 @@ export default function BattleScreen() {
   const { progress, loseLife, markWinRewardPending } = useTowerProgress();
   const currentFloor = progress.currentFloor;
   const isPlayerTurn = turnPhase === 'player';
-  const hasCompleteBattleDeck = pokemonList.length === REQUIRED_PLAYER_DECK_SIZE;
+  const hasCompleteBattleDeck = isDeckLoaded && pokemonList.length === REQUIRED_PLAYER_DECK_SIZE;
   const turnButtonLabel = isPlayerTurn ? '턴 종료' : turnPhase === 'ai' ? '상대 턴' : '대기';
 
   useBgm('bgm/battle-wild.mp3');
@@ -80,10 +81,25 @@ export default function BattleScreen() {
   }, [router]);
 
   useEffect(() => {
-    if (hasCompleteBattleDeck) return;
+    let cancelled = false;
+
+    queueMicrotask(() => {
+      if (cancelled) return;
+
+      setPokemonList(createInitialPokemon());
+      setIsDeckLoaded(true);
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!isDeckLoaded || hasCompleteBattleDeck) return;
 
     handleIncompleteDeck();
-  }, [handleIncompleteDeck, hasCompleteBattleDeck]);
+  }, [handleIncompleteDeck, hasCompleteBattleDeck, isDeckLoaded]);
 
   useEffect(() => {
     window.addEventListener('battle:player-deck-invalid', handleIncompleteDeck);

--- a/src/features/battle/game/battle-scene-constants.ts
+++ b/src/features/battle/game/battle-scene-constants.ts
@@ -1,6 +1,6 @@
 // BattleScene의 카드 배치, 필드 효과, 애니메이션 기준값
 
-import { CARD_W, CARD_H, GAME_WIDTH, GAME_HEIGHT } from './config';
+import { CARD_W, CARD_H, CARD_RENDER_SCALE, GAME_WIDTH, GAME_HEIGHT } from './config';
 
 export const AI_CARD_COUNT = 6;
 export const AI_CARD_SCALE_X = CARD_W / 271;
@@ -24,20 +24,25 @@ export const EASE = {
   rearrange: 'Sine.easeInOut',
 } as const;
 
-export const SCALE = { normal: 0.5, hover: 1.0, drag: 0.625 } as const;
+export const SCALE = {
+  normal: 0.5 * CARD_RENDER_SCALE,
+  hover: 1.0 * CARD_RENDER_SCALE,
+  drag: 0.625 * CARD_RENDER_SCALE,
+  modal: 1.07 * CARD_RENDER_SCALE,
+} as const;
 export const FAN_CFG = { anglePerCard: 8, maxAngle: 60 } as const;
 export const LERP = 0.08;
 
 export const ZONE_CFG = {
   width: CARD_W * 2.0,
   height: CARD_H * 2.0,
-  cardScale: 0.85,
+  cardScale: 0.85 * CARD_RENDER_SCALE,
   cardScaleY: 0.95,
   cardOffsetY: -5,
   gap: 30,
   opponentOffset: 80,
   playerOffset: 50,
-  opponentCardScale: 0.7,
+  opponentCardScale: 0.7 * CARD_RENDER_SCALE,
   opponentCardScaleY: 0.95,
   opponentCardOffsetY: 5,
 } as const;

--- a/src/features/battle/game/config.ts
+++ b/src/features/battle/game/config.ts
@@ -4,6 +4,10 @@ export const GAME_WIDTH = 1920;
 export const GAME_HEIGHT = 1080;
 export const CARD_W = 140;
 export const CARD_H = 200;
+export const CARD_TEXTURE_SCALE = 3;
+export const CARD_TEXTURE_W = CARD_W * CARD_TEXTURE_SCALE;
+export const CARD_TEXTURE_H = CARD_H * CARD_TEXTURE_SCALE;
+export const CARD_RENDER_SCALE = 2 / CARD_TEXTURE_SCALE;
 
 export const phaserConfig = {
   type: 0, // Phaser.AUTO

--- a/src/features/battle/game/scenes/BattleScene.ts
+++ b/src/features/battle/game/scenes/BattleScene.ts
@@ -1,7 +1,7 @@
 ﻿// Phaser 기반 카드 배틀 진행 Scene
 
 import Phaser from 'phaser';
-import { CARD_W, CARD_H } from '../config';
+import { CARD_RENDER_SCALE, CARD_TEXTURE_H, CARD_TEXTURE_W, CARD_W, CARD_H } from '../config';
 import { buildAiDeck } from '@/shared/temp-ai/deck-builder';
 import { chooseForceSwap, chooseMove } from '@/shared/temp-ai/strategy';
 import { createRng, generateSeed, damageRoll, chance } from '@/shared/lib/rng';
@@ -333,7 +333,7 @@ export class BattleScene extends Phaser.Scene {
         ps.setScale(pScaleX, pScaleY);
       }
       if (this.playerHealthBar) {
-        const pHalfH = ((CARD_H * 2) / 2) * pScaleY;
+        const pHalfH = (CARD_TEXTURE_H / 2) * pScaleY;
         this.redrawHealthBar(this.playerHealthBar, cx, py + pHalfH + HEALTH_BAR_GAP_BASE * cardS, pScaleX);
       }
     }
@@ -349,7 +349,7 @@ export class BattleScene extends Phaser.Scene {
         os.setScale(oScaleX, oScaleY);
       }
       if (this.opponentHealthBar) {
-        const oHalfH = ((CARD_H * 2) / 2) * oScaleY;
+        const oHalfH = (CARD_TEXTURE_H / 2) * oScaleY;
         this.redrawHealthBar(this.opponentHealthBar, cx, oy + oHalfH + HEALTH_BAR_GAP_BASE * cardS, oScaleX);
       }
     }
@@ -1163,8 +1163,8 @@ export class BattleScene extends Phaser.Scene {
       targets: card,
       x: targetX,
       y: targetY,
-      scaleX: 1.07,
-      scaleY: 1.07,
+      scaleX: SCALE.modal,
+      scaleY: SCALE.modal,
       duration: FLIGHT_MS,
       ease: 'Cubic.easeOut',
       onComplete: () => {
@@ -1176,7 +1176,7 @@ export class BattleScene extends Phaser.Scene {
       this.tweens.killTweensOf(card);
 
       card.setPosition(targetX, targetY);
-      card.setScale(1.07);
+      card.setScale(SCALE.modal);
       card.setAngle(0);
       card.setAlpha(0);
 
@@ -1279,8 +1279,9 @@ export class BattleScene extends Phaser.Scene {
 
   // HP 바를 Phaser 그래픽 객체로 유지하고 리사이즈와 데미지에 맞춰 다시 그림
   private redrawHealthBar(bar: ZoneHealthBar, cx: number, cy: number, scale: number) {
-    const w = CARD_W * scale * 1.7;
-    const h = Math.max(6, HEALTH_BAR_H_BASE * scale);
+    const logicalScale = scale / CARD_RENDER_SCALE;
+    const w = CARD_TEXTURE_W * scale * 0.85;
+    const h = Math.max(6, HEALTH_BAR_H_BASE * logicalScale);
     const r = h / 2;
     const ratio = Math.max(0, Math.min(1, bar.currentHp / bar.maxHp));
 
@@ -1295,7 +1296,7 @@ export class BattleScene extends Phaser.Scene {
     }
 
     bar.label.setText(`HP ${bar.currentHp} / ${bar.maxHp}`);
-    bar.label.setPosition(cx, cy + h + 4 * scale);
+    bar.label.setPosition(cx, cy + h + 4 * logicalScale);
   }
 
   // 드롭존 카드 아래에 현재 HP를 표시하는 전용 바를 생성함
@@ -1310,7 +1311,7 @@ export class BattleScene extends Phaser.Scene {
     existing?.label.destroy();
 
     const s = this.getZoneCardScale();
-    const cardHalfH = ((CARD_H * 2) / 2) * card.scaleY;
+    const cardHalfH = (CARD_TEXTURE_H / 2) * card.scaleY;
     const cy = card.y + cardHalfH + HEALTH_BAR_GAP_BASE * s;
     const depth = card.depth + 1;
 
@@ -1339,7 +1340,7 @@ export class BattleScene extends Phaser.Scene {
     if (!bar || !card) return;
     bar.currentHp = Math.max(0, hp);
     const s = this.getZoneCardScale();
-    const cardHalfH = ((CARD_H * 2) / 2) * card.scaleY;
+    const cardHalfH = (CARD_TEXTURE_H / 2) * card.scaleY;
     const cy = card.y + cardHalfH + HEALTH_BAR_GAP_BASE * s;
     this.redrawHealthBar(bar, card.x, cy, ZONE_CFG.cardScale * s);
 

--- a/src/features/battle/game/scenes/PreloadScene.ts
+++ b/src/features/battle/game/scenes/PreloadScene.ts
@@ -1,7 +1,7 @@
 // 배틀 화면 이미지와 데이터 사전 로드 Scene
 
 import Phaser from 'phaser';
-import { CARD_W, CARD_H } from '../config';
+import { CARD_W, CARD_H, CARD_TEXTURE_SCALE } from '../config';
 import { readActivePlayerDeckDexIds } from '../player-deck-storage';
 
 export class PreloadScene extends Phaser.Scene {
@@ -29,7 +29,7 @@ export class PreloadScene extends Phaser.Scene {
 
   // 기본 카드 뒷면 텍스처가 없을 때 사용하는 안전한 fallback
   private createCardBack() {
-    const s = 2;
+    const s = CARD_TEXTURE_SCALE;
     const g = this.add.graphics();
     g.fillStyle(0x0d1433);
     g.fillRoundedRect(0, 0, CARD_W * s, CARD_H * s, 10 * s);


### PR DESCRIPTION
# Pull Request

## 🎯 작업 내용

카드 PNG 생성 배율 변경 이후 Phaser 카드 렌더 크기를 기존 비율 기준으로 보정으로 카드를 더욱 선명하게 변경하였습니다. 또한 배틀 페이지 초기 렌더에서 localStorage 덱을 바로 읽지 않도록 변경해 hydration mismatch 가능성을 줄였습니다.


## 📌 작업 배경

이슈 수정

## 🔨 구현 내용

- 카드 PNG 생성 배율 변경 이후 Phaser 카드 렌더 크기를 기존 비율 기준으로 보정했습니다.
- 드롭존 카드와 HP 바 위치 계산을 실제 텍스처 크기 기준으로 맞췄습니다.
- 배틀 페이지 초기 렌더에서 localStorage 덱을 바로 읽지 않도록 변경해 hydration mismatch 가능성을 줄였습니다.
- 카드 뒷면 fallback 텍스처 크기를 카드 PNG 배율과 맞췄습니다.

#### Added (추가)

-

#### Changed (변경)

-

#### Fixed (수정)

-

## 📸 결과물

<img width="703" height="419" alt="image" src="https://github.com/user-attachments/assets/313193b8-d6b0-40ce-8968-7c3e89bf4d28" />


## 🧪 테스트

<!-- 어떻게 테스트했는지 -->

- [x] 로컬 테스트 완료
- [x] 주요 시나리오 검증

## 💬 리뷰 요청사항

- 카드 렌더 크기가 기존 전투 화면 비율과 맞는지 확인 부탁드립니다.
- 배틀 페이지 진입 시 덱 로드와 hydration 에러가 재발하지 않는지 확인 부탁드립니다.

- Closes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * 플레이어 덱 초기 로딩 시 안정성 개선

* **Refactor**
  * 전투 화면의 카드 및 UI 렌더링 스케일 일관성 개선
  * 렌더링 스케일 기준 통일로 카드 표시 안정화

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PODECK/FE/pull/31?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->