### PR TITLE
[Feat] 카드 뽑기 모달 제작

### DIFF
--- a/src/app/(main)/(start)/_types/trainer.ts
+++ b/src/app/(main)/(start)/_types/trainer.ts
@@ -7,4 +7,5 @@ export interface TrainerData {
   createdAt: string;
   selectedPokemons?: SelectedPokemon[];
   activeDeckDexIds?: number[]; // 내 덱 편성에서 쓰일 필드
+  cardPackCount?: number;
 }

--- a/src/app/(main)/pokedex/_components/CardGachaModal.tsx
+++ b/src/app/(main)/pokedex/_components/CardGachaModal.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+import { useState } from 'react';
+import { X, AlertCircle } from 'lucide-react';
+import type { GachaCard } from '@/app/(main)/pokedex/_lib/cardGacha';
+import { pullGacha, saveGachaResult } from '@/app/(main)/pokedex/_lib/cardGacha';
+import GachaLoading from './GachaLoading';
+import GachaReveal from './GachaReveal';
+import GachaResult from './GachaResult';
+
+type Props = {
+  isOpen: boolean;
+  onClose: () => void;
+  packCount: number;
+};
+
+type Step = 1 | 2 | 3;
+
+export default function CardGachaModal({ isOpen, onClose, packCount }: Props) {
+  const [step, setStep] = useState<Step>(1);
+  const [cards, setCards] = useState<GachaCard[]>([]);
+
+  if (!isOpen) return null;
+
+  const handlePull = () => {
+    const result = pullGacha();
+    saveGachaResult(result);
+    setCards(result);
+  };
+
+  const handlePullAgain = () => {
+    setCards([]);
+    setStep(1);
+  };
+
+  const handleClose = () => {
+    setCards([]);
+    setStep(1);
+    onClose();
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center"
+      style={{ backgroundColor: 'var(--color-dimmed)' }}
+      onClick={handleClose}
+    >
+      <div
+        className="relative flex flex-col rounded-[20px] border-4 border-[var(--color-base-1)] bg-white p-8"
+        style={{ width: 720, height: 640 }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* 헤더 */}
+        <div className="mb-6">
+          <h2 className="text-lg leading-none font-bold" style={{ color: 'var(--color-base-0)' }}>
+            카드 뽑기
+          </h2>
+        </div>
+
+        <button
+          type="button"
+          aria-label="닫기"
+          onClick={handleClose}
+          className="absolute top-6 right-6 text-[var(--color-base-1)] transition"
+        >
+          <X size={36} strokeWidth={1.8} />
+        </button>
+
+        {/* 보유 카드팩 없을 때 */}
+        {packCount === 0 ? (
+          <div className="flex flex-1 flex-col">
+            <div className="flex flex-1 flex-col items-center justify-center gap-2">
+              <AlertCircle size={52} style={{ color: '#ccc' }} className="mb-2" />
+              <p className="text-3xl font-bold" style={{ color: 'var(--color-base-0)' }}>
+                보유한 카드팩이 없어요
+              </p>
+              <p className="text-lg" style={{ color: '#666666' }}>
+                배틀에서 승리해 카드팩을 획득해보세요!
+              </p>
+            </div>
+            <div className="flex justify-center py-[40px]">
+              <button
+                onClick={handleClose}
+                className="rounded-xl text-lg font-bold"
+                style={{ width: 180, height: 65, backgroundColor: 'var(--color-base-2)', color: 'var(--color-base-0)' }}
+              >
+                닫기
+              </button>
+            </div>
+          </div>
+        ) : (
+          <div className="flex flex-1 flex-col">
+            {step === 1 && <GachaLoading onPull={handlePull} onComplete={() => setStep(2)} />}
+            {step === 2 && <GachaReveal cards={cards} onComplete={() => setStep(3)} />}
+            {step === 3 && (
+              <GachaResult cards={cards} packCount={packCount} onPullAgain={handlePullAgain} onClose={handleClose} />
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(main)/pokedex/_components/CardGachaModal.tsx
+++ b/src/app/(main)/pokedex/_components/CardGachaModal.tsx
@@ -23,9 +23,14 @@ export default function CardGachaModal({ isOpen, onClose, packCount }: Props) {
   if (!isOpen) return null;
 
   const handlePull = () => {
-    const result = pullGacha();
-    saveGachaResult(result);
-    setCards(result);
+    try {
+      const result = pullGacha();
+      saveGachaResult(result);
+      setCards(result);
+    } catch {
+      setCards([]);
+      setStep(1);
+    }
   };
 
   const handlePullAgain = () => {
@@ -42,6 +47,9 @@ export default function CardGachaModal({ isOpen, onClose, packCount }: Props) {
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="card-gacha-modal-title"
       style={{ backgroundColor: 'var(--color-dimmed)' }}
       onClick={handleClose}
     >
@@ -52,7 +60,11 @@ export default function CardGachaModal({ isOpen, onClose, packCount }: Props) {
       >
         {/* 헤더 */}
         <div className="mb-6">
-          <h2 className="text-lg leading-none font-bold" style={{ color: 'var(--color-base-0)' }}>
+          <h2
+            id="card-gacha-modal-title"
+            className="text-lg leading-none font-bold"
+            style={{ color: 'var(--color-base-0)' }}
+          >
             카드 뽑기
           </h2>
         </div>

--- a/src/app/(main)/pokedex/_components/CardGachaModal.tsx
+++ b/src/app/(main)/pokedex/_components/CardGachaModal.tsx
@@ -73,7 +73,7 @@ export default function CardGachaModal({ isOpen, onClose, packCount }: Props) {
           type="button"
           aria-label="닫기"
           onClick={handleClose}
-          className="absolute top-6 right-6 text-[var(--color-base-1)] transition"
+          className="absolute top-6 right-6 cursor-pointer text-[var(--color-base-1)] transition-opacity duration-200 hover:opacity-70"
         >
           <X size={36} strokeWidth={1.8} />
         </button>
@@ -93,7 +93,7 @@ export default function CardGachaModal({ isOpen, onClose, packCount }: Props) {
             <div className="flex justify-center py-[40px]">
               <button
                 onClick={handleClose}
-                className="rounded-xl text-lg font-bold"
+                className="cursor-pointer rounded-xl text-lg font-bold transition-opacity duration-200 hover:opacity-70"
                 style={{ width: 180, height: 65, backgroundColor: 'var(--color-base-2)', color: 'var(--color-base-0)' }}
               >
                 닫기

--- a/src/app/(main)/pokedex/_components/DexPage.tsx
+++ b/src/app/(main)/pokedex/_components/DexPage.tsx
@@ -13,6 +13,7 @@ import Pagination from './Pagination';
 import FloatingButton from '@/app/(main)/pokedex/_components/FloatingButton';
 import PokemonDetailModal from '@/shared/components/pokemon/PokemonDetailModal';
 import HomeHeader from '@/shared/components/HomeHeader';
+import CardGachaModal from './CardGachaModal';
 
 const ITEMS_PER_PAGE = 20;
 
@@ -51,12 +52,18 @@ export default function DexPage() {
   const [types, setTypes] = useState<PokemonType[]>([] as PokemonType[]);
   const [page, setPage] = useState(1);
   const [selectedPokemon, setSelectedPokemon] = useState<PokemonData | null>(null);
+  const [isGachaOpen, setIsGachaOpen] = useState(false);
   const trainerDataJson = useSyncExternalStore(subscribeToStorage, getTrainerDataSnapshot, getServerSnapshot);
   const ownedPokemonIds = useMemo(() => parseOwnedPokemonIds(trainerDataJson), [trainerDataJson]);
   const selectedPokemonCount = ownedPokemonIds.length;
-
-  //임시 - 카드 뽑기 기능 작업 후 로컬스토리지 연동 예정
-  const [cardPackCount] = useState(5);
+  const cardPackCount = useMemo(() => {
+    if (!trainerDataJson) return 0;
+    try {
+      return (JSON.parse(trainerDataJson) as { cardPackCount?: number }).cardPackCount ?? 0;
+    } catch {
+      return 0;
+    }
+  }, [trainerDataJson]);
 
   //필터 변경 시 페이지 초기화
   const handleSetSearch = (value: string) => {
@@ -114,10 +121,9 @@ export default function DexPage() {
           onClose={() => setSelectedPokemon(null)}
         />
 
-        <FloatingButton
-          cardPackCount={cardPackCount}
-          onClick={() => console.log('카드뽑기 모달 열기')} //임시
-        />
+        <FloatingButton cardPackCount={cardPackCount} onClick={() => setIsGachaOpen(true)} />
+
+        <CardGachaModal isOpen={isGachaOpen} onClose={() => setIsGachaOpen(false)} packCount={cardPackCount} />
       </main>
     </div>
   );

--- a/src/app/(main)/pokedex/_components/DexPage.tsx
+++ b/src/app/(main)/pokedex/_components/DexPage.tsx
@@ -59,7 +59,9 @@ export default function DexPage() {
   const cardPackCount = useMemo(() => {
     if (!trainerDataJson) return 0;
     try {
-      return (JSON.parse(trainerDataJson) as { cardPackCount?: number }).cardPackCount ?? 0;
+      const raw = (JSON.parse(trainerDataJson) as { cardPackCount?: number }).cardPackCount;
+      if (!Number.isFinite(raw)) return 0;
+      return Math.max(0, Math.floor(raw ?? 0));
     } catch {
       return 0;
     }

--- a/src/app/(main)/pokedex/_components/FloatingButton.tsx
+++ b/src/app/(main)/pokedex/_components/FloatingButton.tsx
@@ -36,7 +36,7 @@ export default function FloatingButton({ cardPackCount, onClick }: Props) {
           style={{
             width: '24px',
             height: '24px',
-            backgroundColor: 'var(--color-primary)',
+            backgroundColor: cardPackCount === 0 ? 'var(--color-base-1)' : 'var(--color-primary)',
             top: '-5px',
             right: '-5px',
           }}

--- a/src/app/(main)/pokedex/_components/GachaCardItem.module.css
+++ b/src/app/(main)/pokedex/_components/GachaCardItem.module.css
@@ -1,4 +1,4 @@
-@keyframes cardShine {
+@keyframes card-shine {
   0% {
     transform: translateX(-60%);
   }
@@ -16,5 +16,5 @@
   background: linear-gradient(115deg, transparent 15%, rgba(255, 255, 255, 0.3) 50%, transparent 85%);
   width: 200%;
   left: -100%;
-  animation: cardShine 5s ease-in-out 1s infinite;
+  animation: card-shine 5s ease-in-out 1s infinite;
 }

--- a/src/app/(main)/pokedex/_components/GachaCardItem.module.css
+++ b/src/app/(main)/pokedex/_components/GachaCardItem.module.css
@@ -1,0 +1,20 @@
+@keyframes cardShine {
+  0% {
+    transform: translateX(-60%);
+  }
+  35% {
+    transform: translateX(110%);
+  }
+  100% {
+    transform: translateX(110%);
+  }
+}
+
+.shine {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(115deg, transparent 15%, rgba(255, 255, 255, 0.3) 50%, transparent 85%);
+  width: 200%;
+  left: -100%;
+  animation: cardShine 5s ease-in-out 1s infinite;
+}

--- a/src/app/(main)/pokedex/_components/GachaCardItem.tsx
+++ b/src/app/(main)/pokedex/_components/GachaCardItem.tsx
@@ -13,7 +13,13 @@ type Props = {
 
 export default function GachaCardItem({ card, isRevealed, onClick }: Props) {
   return (
-    <div className="relative cursor-pointer" style={{ width: 120, height: 168, perspective: 1000 }} onClick={onClick}>
+    <button
+      type="button"
+      onClick={onClick}
+      className="relative cursor-pointer"
+      style={{ width: 120, height: 168, perspective: 1000 }}
+      aria-label={`${card.pokemon.koName} 카드 ${isRevealed ? '정보' : '공개'}`}
+    >
       <motion.div
         animate={{ rotateY: isRevealed ? 180 : 0, y: 0 }}
         whileHover={!isRevealed ? { y: 10, transition: { duration: 0.15 } } : {}}
@@ -89,6 +95,6 @@ export default function GachaCardItem({ card, isRevealed, onClick }: Props) {
           <div className={styles.shine} />
         </div>
       )}
-    </div>
+    </button>
   );
 }

--- a/src/app/(main)/pokedex/_components/GachaCardItem.tsx
+++ b/src/app/(main)/pokedex/_components/GachaCardItem.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import Image from 'next/image';
+import { motion } from 'framer-motion';
+import type { GachaCard } from '@/app/(main)/pokedex/_lib/cardGacha';
+import styles from './GachaCardItem.module.css';
+
+type Props = {
+  card: GachaCard;
+  isRevealed: boolean;
+  onClick: () => void;
+};
+
+export default function GachaCardItem({ card, isRevealed, onClick }: Props) {
+  return (
+    <div className="relative cursor-pointer" style={{ width: 120, height: 168, perspective: 1000 }} onClick={onClick}>
+      <motion.div
+        animate={{ rotateY: isRevealed ? 180 : 0, y: 0 }}
+        whileHover={!isRevealed ? { y: 10, transition: { duration: 0.15 } } : {}}
+        transition={{ duration: 0.5 }}
+        style={{ width: '100%', height: '100%', transformStyle: 'preserve-3d', position: 'relative' }}
+      >
+        {/* 뒷면 */}
+        <div
+          className="absolute inset-0 flex items-center justify-center overflow-hidden rounded-lg"
+          style={{
+            backfaceVisibility: 'hidden',
+            outline: '4px solid #EBEBEB',
+            backgroundColor: 'white',
+          }}
+        >
+          <Image
+            src="/images/silhouette.svg"
+            alt="실루엣"
+            width={80}
+            height={80}
+            style={{ filter: 'invert(1)', opacity: 0.1 }}
+          />
+        </div>
+
+        {/* 앞면 */}
+        <div
+          className="absolute inset-0 rounded-lg"
+          style={{
+            backfaceVisibility: 'hidden',
+            transform: 'rotateY(180deg)',
+            outline: `4px solid ${card.isNew ? '#FFEBC5' : '#EBEBEB'}`,
+          }}
+        >
+          <div className="absolute inset-0 overflow-hidden rounded-lg">
+            <Image
+              src={`/images/pokemon-cards/${card.pokemon.dexId}.png`}
+              alt={card.pokemon.koName}
+              fill
+              className="object-cover"
+            />
+          </div>
+        </div>
+      </motion.div>
+
+      {/* 신규 / 중복 뱃지 */}
+      {isRevealed && (
+        <span
+          className="absolute top-[-32px] right-[-3px] flex items-center justify-center rounded-full text-xs font-bold text-[var(--color-base-3)]"
+          style={{ width: 40, height: 20, backgroundColor: card.isNew ? 'var(--color-primary)' : '#ccc' }}
+        >
+          {card.isNew ? 'NEW' : '중복'}
+        </span>
+      )}
+
+      {/* 신규 카드 glow 효과 */}
+      {isRevealed && card.isNew && (
+        <motion.div
+          className="pointer-events-none absolute inset-0 rounded-lg"
+          animate={{
+            boxShadow: [
+              '0 0 8px 2px rgba(255, 180, 29, 0.2)',
+              '0 0 24px 10px rgba(255, 180, 29, 0.2)',
+              '0 0 8px 2px rgba(255, 180, 29, 0.2)',
+            ],
+          }}
+          transition={{ duration: 2, repeat: Infinity, ease: 'easeInOut' }}
+        />
+      )}
+
+      {/* 신규 카드 shine 효과 */}
+      {isRevealed && card.isNew && (
+        <div className="pointer-events-none absolute inset-0 overflow-hidden rounded-lg">
+          <div className={styles.shine} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/(main)/pokedex/_components/GachaCardItem.tsx
+++ b/src/app/(main)/pokedex/_components/GachaCardItem.tsx
@@ -16,7 +16,7 @@ export default function GachaCardItem({ card, isRevealed, onClick }: Props) {
     <button
       type="button"
       onClick={onClick}
-      className="relative cursor-pointer"
+      className={`relative ${isRevealed ? 'pointer-events-none cursor-default' : 'cursor-pointer'}`}
       style={{ width: 120, height: 168, perspective: 1000 }}
       aria-label={`${card.pokemon.koName} 카드 ${isRevealed ? '정보' : '공개'}`}
     >

--- a/src/app/(main)/pokedex/_components/GachaLoading.tsx
+++ b/src/app/(main)/pokedex/_components/GachaLoading.tsx
@@ -111,7 +111,7 @@ export default function GachaLoading({ onPull, onComplete }: Props) {
         <div className="flex justify-center py-[40px]">
           <button
             onClick={handlePull}
-            className="rounded-xl text-lg font-bold"
+            className="cursor-pointer rounded-xl text-lg font-bold transition-opacity duration-200 hover:opacity-70"
             style={{ width: 180, height: 65, backgroundColor: 'var(--color-primary)', color: 'var(--color-base-3)' }}
           >
             뽑기

--- a/src/app/(main)/pokedex/_components/GachaLoading.tsx
+++ b/src/app/(main)/pokedex/_components/GachaLoading.tsx
@@ -1,0 +1,131 @@
+'use client';
+
+import { useState, useEffect, useRef } from 'react';
+import { motion } from 'framer-motion';
+import { Sparkle } from 'lucide-react';
+import Typewriter from 'typewriter-effect';
+
+type Props = {
+  onPull: () => void;
+  onComplete: () => void;
+};
+
+type Phase = 'idle' | 'shaking' | 'opening';
+
+export default function GachaLoading({ onPull, onComplete }: Props) {
+  const [phase, setPhase] = useState<Phase>('idle');
+  const t1 = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const t2 = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (t1.current) clearTimeout(t1.current);
+      if (t2.current) clearTimeout(t2.current);
+    };
+  }, []);
+
+  const handlePull = () => {
+    onPull();
+    setPhase('shaking');
+    t1.current = setTimeout(() => {
+      setPhase('opening');
+      t2.current = setTimeout(() => {
+        onComplete();
+      }, 1000);
+    }, 2000);
+  };
+
+  return (
+    <div className="flex w-full flex-1 flex-col">
+      <div className="flex flex-1 flex-col items-center justify-center gap-12">
+        {phase === 'idle' && (
+          <p className="text-2xl font-bold" style={{ color: 'var(--color-base-0)' }}>
+            카드팩을 열어볼까요?
+          </p>
+        )}
+
+        <div className="relative" style={{ perspective: 1000, width: 160, height: 224 }}>
+          {phase === 'idle' &&
+            [
+              { top: -10, left: -64, size: 56, delay: 0, duration: 2.0 },
+              { top: -28, right: -54, size: 32, delay: 0.8, duration: 2.3 },
+              { bottom: -30, left: -44, size: 40, delay: 1.4, duration: 1.9 },
+              { bottom: -34, right: -34, size: 24, delay: 0.4, duration: 2.2 },
+            ].map((s, i) => (
+              <motion.div
+                key={i}
+                className="pointer-events-none absolute"
+                style={{ top: s.top, bottom: s.bottom, left: s.left, right: s.right }}
+                animate={{ opacity: [0, 1, 0], scale: [0.5, 1, 0.5] }}
+                transition={{ duration: s.duration, delay: s.delay, repeat: Infinity, ease: 'easeInOut' }}
+              >
+                <Sparkle size={s.size} fill="#eee" stroke="none" />
+              </motion.div>
+            ))}
+          <motion.div
+            animate={
+              phase === 'idle'
+                ? { rotate: [0, 8, -8, 0], scale: [1, 1.05, 1] }
+                : phase === 'shaking'
+                  ? { rotate: [0, 8, -8, 8, -8, 8, -8, 0], scale: [1, 1.05, 1.05, 1.05, 1.05, 1.05, 1.05, 1] }
+                  : { rotate: 0, scale: 1 }
+            }
+            transition={
+              phase === 'idle' ? { duration: 1.5, repeat: 1, ease: 'easeInOut' } : { duration: 1.2, ease: 'easeInOut' }
+            }
+            className="relative flex items-center justify-center rounded-xl"
+            style={{
+              width: 160,
+              height: 224,
+              backgroundImage: 'linear-gradient(125deg, #ffc0e8, #ffd4a0, #a8f0e8, #d4a8f0, #ffc0e8)',
+              backgroundSize: '300% 300%',
+              animation: 'hologram 3s ease infinite',
+              boxShadow: '0 8px 32px rgba(0,0,0,0.15)',
+              outline: '5px solid #EBEBEB',
+            }}
+          >
+            <span className="text-6xl font-black text-white/80 select-none">?</span>
+          </motion.div>
+        </div>
+
+        {phase !== 'idle' && (
+          <div className="text-2xl font-bold" style={{ color: 'var(--color-base-0)' }}>
+            <Typewriter
+              options={{ loop: true, delay: 150, deleteSpeed: 80 }}
+              onInit={(typewriter) => {
+                typewriter
+                  .typeString('카드팩을 여는 중')
+                  .typeString('.')
+                  .typeString('.')
+                  .typeString('.')
+                  .pauseFor(400)
+                  .deleteChars(3)
+                  .start();
+              }}
+            />
+          </div>
+        )}
+      </div>
+
+      {phase === 'idle' && (
+        <div className="flex justify-center py-[40px]">
+          <button
+            onClick={handlePull}
+            className="rounded-xl text-lg font-bold"
+            style={{ width: 180, height: 65, backgroundColor: 'var(--color-primary)', color: 'var(--color-base-3)' }}
+          >
+            뽑기
+          </button>
+        </div>
+      )}
+
+      <style>{`
+        @keyframes hologram {
+          0% { background-position: 0% 50%; }
+          50% { background-position: 100% 50%; }
+          100% { background-position: 0% 50%; }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/src/app/(main)/pokedex/_components/GachaResult.tsx
+++ b/src/app/(main)/pokedex/_components/GachaResult.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import type { GachaCard } from '@/app/(main)/pokedex/_lib/cardGacha';
+import GachaCardItem from './GachaCardItem';
+
+type Props = {
+  cards: GachaCard[];
+  packCount: number;
+  onPullAgain: () => void;
+  onClose: () => void;
+};
+
+export default function GachaResult({ cards, packCount, onPullAgain, onClose }: Props) {
+  const newCount = cards.filter((c) => c.isNew).length;
+  const dupCount = cards.length - newCount;
+
+  return (
+    <div className="flex w-full flex-1 flex-col">
+      <div className="flex flex-1 flex-col items-center justify-center gap-16">
+        <div className="text-center">
+          <h2 className="text-[32px] font-bold" style={{ color: 'var(--color-base-0)' }}>
+            획득한 카드
+          </h2>
+          <p className="mt-1 text-lg" style={{ color: '#666666' }}>
+            신규 카드 <span className="font-bold">{newCount}</span> 장&nbsp;<span style={{ color: '#ccc' }}>|</span>
+            &nbsp;중복 카드 <span className="font-bold">{dupCount}</span> 장
+          </p>
+        </div>
+
+        <div className="flex gap-[15px]">
+          {cards.map((card) => (
+            <GachaCardItem key={card.pokemon.dexId} card={card} isRevealed={true} onClick={() => {}} />
+          ))}
+        </div>
+      </div>
+
+      <div className="flex justify-center gap-3 py-[40px]">
+        {/* 한 번 더 뽑기 버튼, 말풍선 */}
+        <div className="relative flex flex-col items-center">
+          {packCount > 0 && (
+            <motion.div
+              className="absolute bottom-full mb-2"
+              animate={{ y: [0, -4, 0] }}
+              transition={{ duration: 1, repeat: Infinity, ease: 'easeInOut' }}
+            >
+              <div
+                className="rounded-lg px-3 py-1.5 text-sm font-semibold text-white"
+                style={{ backgroundColor: 'var(--color-secondary-1)' }}
+              >
+                남은 카드팩 {packCount}개
+              </div>
+              {/* 말풍선 꼬리 */}
+              <div
+                className="absolute left-1/2 -translate-x-1/2"
+                style={{
+                  top: 'calc(100% - 1px)',
+                  width: 0,
+                  height: 0,
+                  borderLeft: '6px solid transparent',
+                  borderRight: '6px solid transparent',
+                  borderTop: `6px solid var(--color-secondary-1)`,
+                }}
+              />
+            </motion.div>
+          )}
+          <button
+            onClick={onPullAgain}
+            disabled={packCount === 0}
+            className="rounded-xl text-lg font-bold disabled:opacity-40"
+            style={{ width: 180, height: 65, backgroundColor: 'var(--color-primary)', color: 'var(--color-base-3)' }}
+          >
+            한 번 더 뽑기
+          </button>
+        </div>
+
+        <button
+          onClick={onClose}
+          className="rounded-xl text-lg font-bold"
+          style={{ width: 180, height: 65, backgroundColor: 'var(--color-base-2)', color: 'var(--color-secondary-1)' }}
+        >
+          닫기
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(main)/pokedex/_components/GachaResult.tsx
+++ b/src/app/(main)/pokedex/_components/GachaResult.tsx
@@ -67,7 +67,7 @@ export default function GachaResult({ cards, packCount, onPullAgain, onClose }: 
           <button
             onClick={onPullAgain}
             disabled={packCount === 0}
-            className="rounded-xl text-lg font-bold disabled:opacity-40"
+            className="cursor-pointer rounded-xl text-lg font-bold transition-opacity duration-200 enabled:hover:opacity-70 disabled:opacity-40"
             style={{ width: 180, height: 65, backgroundColor: 'var(--color-primary)', color: 'var(--color-base-3)' }}
           >
             한 번 더 뽑기
@@ -76,7 +76,7 @@ export default function GachaResult({ cards, packCount, onPullAgain, onClose }: 
 
         <button
           onClick={onClose}
-          className="rounded-xl text-lg font-bold"
+          className="cursor-pointer rounded-xl text-lg font-bold transition-opacity duration-200 hover:opacity-70"
           style={{ width: 180, height: 65, backgroundColor: 'var(--color-base-2)', color: 'var(--color-secondary-1)' }}
         >
           닫기

--- a/src/app/(main)/pokedex/_components/GachaReveal.tsx
+++ b/src/app/(main)/pokedex/_components/GachaReveal.tsx
@@ -51,14 +51,14 @@ export default function GachaReveal({ cards, onComplete }: Props) {
         <button
           onClick={handleRevealAll}
           disabled={revealed.every(Boolean)}
-          className="rounded-xl text-lg font-bold disabled:opacity-50"
+          className="cursor-pointer rounded-xl text-lg font-bold transition-opacity duration-200 enabled:hover:opacity-70 disabled:opacity-50"
           style={{ width: 180, height: 65, backgroundColor: 'var(--color-primary)', color: 'var(--color-base-3)' }}
         >
           모두 공개
         </button>
         <button
           onClick={onComplete}
-          className="rounded-xl text-lg font-bold"
+          className="cursor-pointer rounded-xl text-lg font-bold transition-opacity duration-200 hover:opacity-70"
           style={{ width: 180, height: 65, backgroundColor: 'var(--color-secondary-1)', color: 'var(--color-base-3)' }}
         >
           다음

--- a/src/app/(main)/pokedex/_components/GachaReveal.tsx
+++ b/src/app/(main)/pokedex/_components/GachaReveal.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import { useState } from 'react';
+import { motion } from 'framer-motion';
+import type { GachaCard } from '@/app/(main)/pokedex/_lib/cardGacha';
+import GachaCardItem from './GachaCardItem';
+
+type Props = {
+  cards: GachaCard[];
+  onComplete: () => void;
+};
+
+export default function GachaReveal({ cards, onComplete }: Props) {
+  const [revealed, setRevealed] = useState<boolean[]>(Array(cards.length).fill(false));
+
+  const handleReveal = (index: number) => {
+    setRevealed((prev) => prev.map((v, i) => (i === index ? true : v)));
+  };
+
+  const handleRevealAll = () => {
+    setRevealed(Array(cards.length).fill(true));
+  };
+
+  return (
+    <div className="flex w-full flex-1 flex-col">
+      <div className="flex flex-1 flex-col items-center justify-center gap-16">
+        <div className="text-center">
+          <h2 className="text-[32px] font-bold" style={{ color: 'var(--color-base-0)' }}>
+            획득한 카드
+          </h2>
+          <p className="mt-1 text-lg" style={{ color: '#666666' }}>
+            카드를 눌러 결과를 확인하세요
+          </p>
+        </div>
+
+        <div className="flex gap-[15px]">
+          {cards.map((card, index) => (
+            <motion.div
+              key={card.pokemon.dexId}
+              initial={{ y: 30, opacity: 0 }}
+              animate={{ y: 0, opacity: 1 }}
+              transition={{ type: 'tween', ease: [0.22, 1, 0.36, 1], duration: 0.5, delay: index * 0.08 }}
+            >
+              <GachaCardItem card={card} isRevealed={revealed[index]} onClick={() => handleReveal(index)} />
+            </motion.div>
+          ))}
+        </div>
+      </div>
+
+      <div className="flex justify-center gap-[15px] py-[40px]">
+        <button
+          onClick={handleRevealAll}
+          disabled={revealed.every(Boolean)}
+          className="rounded-xl text-lg font-bold disabled:opacity-50"
+          style={{ width: 180, height: 65, backgroundColor: 'var(--color-primary)', color: 'var(--color-base-3)' }}
+        >
+          모두 공개
+        </button>
+        <button
+          onClick={onComplete}
+          className="rounded-xl text-lg font-bold"
+          style={{ width: 180, height: 65, backgroundColor: 'var(--color-secondary-1)', color: 'var(--color-base-3)' }}
+        >
+          다음
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(main)/pokedex/_lib/cardGacha.ts
+++ b/src/app/(main)/pokedex/_lib/cardGacha.ts
@@ -1,0 +1,73 @@
+import pokemonData from '@/../data/pokemon.json';
+import type { PokemonData } from '@/shared/types/pokemon';
+import type { TrainerData } from '@/app/(main)/(start)/_types/trainer';
+import { storageKeys } from '@/app/(main)/(start)/_constants/key';
+
+export type GachaCard = {
+  pokemon: PokemonData;
+  isNew: boolean;
+};
+
+const GACHA_COUNT = 5;
+
+// Gen 1-4 뽑기 제외 포켓몬 목록
+const GACHA_EXCLUDED_IDS = new Set([
+  // Gen 1
+  144, 145, 146, 150, 151,
+  // Gen 2
+  243, 244, 245, 249, 250, 251,
+  // Gen 3
+  377, 378, 379, 380, 381, 382, 383, 384, 385, 386,
+  // Gen 4
+  480, 481, 482, 483, 484, 485, 486, 487, 488, 489, 490, 491, 492, 493,
+]);
+
+// 뽑기 풀 — 빌드 타임 고정값이므로 모듈 레벨에서 한 번만 계산
+const GACHA_POOL = (Object.values(pokemonData) as PokemonData[]).filter(
+  (p) => p.evolutionStage === 1 && !GACHA_EXCLUDED_IDS.has(p.dexId),
+);
+
+function getTrainerData(): TrainerData | null {
+  const raw = localStorage.getItem(storageKeys.TRAINER_DATA);
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as TrainerData;
+  } catch {
+    return null;
+  }
+}
+
+export function getCardPackCount(): number {
+  return getTrainerData()?.cardPackCount ?? 0;
+}
+
+export function pullGacha(): GachaCard[] {
+  const pool = GACHA_POOL;
+
+  const trainerData = getTrainerData();
+  const ownedIds = new Set(trainerData?.selectedPokemons?.map((p) => p.dexId) ?? []);
+
+  const shuffled = [...pool].sort(() => Math.random() - 0.5);
+  const pulled = shuffled.slice(0, GACHA_COUNT);
+
+  return pulled.map((pokemon) => ({
+    pokemon,
+    isNew: !ownedIds.has(pokemon.dexId),
+  }));
+}
+
+export function saveGachaResult(gachaCards: GachaCard[]): void {
+  const trainerData = getTrainerData();
+  if (!trainerData) return;
+
+  const newPokemons = gachaCards.filter((c) => c.isNew).map((c) => c.pokemon);
+
+  const updated: TrainerData = {
+    ...trainerData,
+    selectedPokemons: [...(trainerData.selectedPokemons ?? []), ...newPokemons],
+    cardPackCount: Math.max(0, (trainerData.cardPackCount ?? 0) - 1),
+  };
+
+  localStorage.setItem(storageKeys.TRAINER_DATA, JSON.stringify(updated));
+  window.dispatchEvent(new CustomEvent('trainer-data-updated'));
+}

--- a/src/app/(main)/pokedex/_lib/cardGacha.ts
+++ b/src/app/(main)/pokedex/_lib/cardGacha.ts
@@ -24,7 +24,7 @@ const GACHA_EXCLUDED_IDS = new Set([
 
 // 뽑기 풀 — 빌드 타임 고정값이므로 모듈 레벨에서 한 번만 계산
 const GACHA_POOL = (Object.values(pokemonData) as PokemonData[]).filter(
-  (p) => p.evolutionStage === 1 && !GACHA_EXCLUDED_IDS.has(p.dexId),
+  (p) => p.dexId <= 493 && p.evolutionStage === 1 && !GACHA_EXCLUDED_IDS.has(p.dexId),
 );
 
 function getTrainerData(): TrainerData | null {
@@ -59,6 +59,7 @@ export function pullGacha(): GachaCard[] {
 export function saveGachaResult(gachaCards: GachaCard[]): void {
   const trainerData = getTrainerData();
   if (!trainerData) return;
+  if ((trainerData.cardPackCount ?? 0) <= 0) return;
 
   const newPokemons = gachaCards.filter((c) => c.isNew).map((c) => c.pokemon);
 


### PR DESCRIPTION
# Pull Request

## 🎯 작업 내용

카드 뽑기 모달 구현

## 📌 작업 배경

카드팩을 열어 새 포켓몬 카드를 수집할 수 있는 기능을 구현했습니다. 

## 🔨 구현 내용

#### Added (추가)

- 카드팩 뽑기 모달 컴포넌트 추가 (CardGachaModal) - 3단계 플로우 (로딩 → 공개 → 결과)
- 카드 뽑기 로직 추가 (_lib/cardGacha.ts) - 1~4세대 일부 포켓몬(전설/준전설/환상) 제외한 포켓몬으로 풀 구성
- GachaCardItem 카드 뒤집기 애니메이션 컴포넌트 추가 - 신규 카드 glow, shine 효과
- GachaLoading 홀로그램 카드팩 애니메이션 컴포넌트 추가
- FloatingButton 카드팩 수 뱃지 UI 추가 (보유 여부에 따른 색상 분기)

#### Changed (변경)

- TrainerData 타입에 cardPackCount 필드 추가
- FloatingButton 컴포넌트에 카드팩 수 표시 기능 추가
- DexPage 카드 뽑기 모달 연결

#### Fixed (수정)

-

## 📸 결과물


https://github.com/user-attachments/assets/47946894-dea1-47d6-8018-dad727354df3


## 🧪 테스트

- [x] 로컬 테스트 완료
- [x] 카드팩 보유 시 뽑기 모달 정상 진입
- [x] 카드팩 미보유 시 빈 상태 화면 노출
- [x] 카드 5장 뽑기 후 신규/중복 판별 정상 동작
- [x] 뽑기 후 `cardPackCount` 1 차감 확인
- [x] 신규 포켓몬이 `selectedPokemons`에 추가되는지 확인
- [x] 다시 뽑기 시 플로우 초기화 확인
- [ ] 전설/준전설/환상 포켓몬이 뽑기 결과에 포함되지 않는지 확인

## 💬 리뷰 요청사항

확인 부탁드립니다. 감사합니다!

## 🔗 관련 링크

- Closes #33


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 모달 기반 카드 뽑기(오픈) 흐름 추가 — 로딩→공개→결과 단계 제공
  * 3D 플립 카드 공개 UI 및 클릭 기반 개별 공개/전체 공개 기능 추가
  * 신규 카드 시각 피드백(NEW 배지, 글로우·샤인 애니메이션) 제공
  * 남은 카드팩 수 표시 및 소진 처리(0일 때 동작 비활성화)
  * 트레이너 데이터에 카드팩 개수 저장 가능(선택 필드)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PODECK/FE/pull/33?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->