### PR TITLE
[Design] 카드팩 안내 및 포켓몬 상세 모달 UI 조정

### DIFF
--- a/src/app/(main)/home/_components/TrainerStatusBar.tsx
+++ b/src/app/(main)/home/_components/TrainerStatusBar.tsx
@@ -2,9 +2,7 @@
 
 // 트레이너 현황 바 — 닉네임, 카드팩, 탑 진행도, 배틀 전적 표시
 
-import { X } from 'lucide-react';
 import { useRouter } from 'next/navigation';
-import { useState } from 'react';
 import Typewriter from 'typewriter-effect';
 
 interface TrainerStatusBarProps {
@@ -21,16 +19,10 @@ export default function TrainerStatusBar({
   battleRecord,
 }: TrainerStatusBarProps) {
   const router = useRouter();
-  const [isPackGuideOpen, setIsPackGuideOpen] = useState(false);
   const hasCardPack = cardPackCount > 0;
 
-  const handleOpenPackGuide = () => {
-    if (!hasCardPack) return;
-    setIsPackGuideOpen(true);
-  };
-
   const handleMoveToPokedex = () => {
-    setIsPackGuideOpen(false);
+    if (!hasCardPack) return;
     router.push('/pokedex');
   };
 
@@ -53,14 +45,21 @@ export default function TrainerStatusBar({
           <div className="relative">
             <button
               type="button"
-              onClick={handleOpenPackGuide}
+              onClick={handleMoveToPokedex}
               disabled={!hasCardPack}
-              className="text-[#E0E0E0] transition hover:text-white disabled:cursor-default disabled:hover:text-[#E0E0E0]"
+              aria-describedby={hasCardPack ? 'card-pack-tooltip' : undefined}
+              className="cursor-pointer text-[#E0E0E0] transition hover:text-[var(--color-base-3)] disabled:hover:text-[#E0E0E0]"
             >
               보유 카드팩 <strong className="text-[#FFF]">{cardPackCount}</strong> 개
             </button>
             {hasCardPack && (
-              <span className="absolute -top-2 -right-3 h-2.5 w-2.5 rounded-full bg-[var(--color-primary)]" />
+              <span
+                role="tooltip"
+                className="pointer-events-none absolute bottom-[calc(100%+10px)] left-1/2 z-30 w-max -translate-x-[45%] rounded-[10px] bg-[var(--color-primary)] px-2.5 py-2 text-[15px] leading-none font-extrabold whitespace-nowrap text-[var(--color-base-3)] shadow-[0_8px_14px_rgba(0,0,0,0.16)]"
+              >
+                열 수 있는 카드팩이 있어요!
+                <span className="absolute top-full left-1/2 h-0 w-0 -translate-x-1/2 border-x-[5px] border-t-[7px] border-x-transparent border-t-[var(--color-primary)]" />
+              </span>
             )}
           </div>
           <span className="pl-[3px] text-[#C0C0C0]">|</span>
@@ -75,45 +74,6 @@ export default function TrainerStatusBar({
           </span>
         </div>
       </section>
-
-      {isPackGuideOpen && (
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/35 px-4"
-          role="dialog"
-          aria-modal="true"
-          aria-labelledby="card-pack-guide-title"
-          onClick={() => setIsPackGuideOpen(false)}
-        >
-          <div
-            className="relative w-full max-w-[420px] rounded-[18px] bg-white px-8 py-9 text-center shadow-[0_18px_50px_rgba(0,0,0,0.18)]"
-            onClick={(event) => event.stopPropagation()}
-          >
-            <button
-              type="button"
-              aria-label="닫기"
-              onClick={() => setIsPackGuideOpen(false)}
-              className="absolute top-5 right-5 text-[#999999] transition hover:text-[#555555]"
-            >
-              <X size={28} strokeWidth={2} />
-            </button>
-
-            <p id="card-pack-guide-title" className="text-2xl font-extrabold text-[var(--color-base-0)]">
-              새로운 카드팩을 뽑을 수 있어요!
-            </p>
-            <p className="mt-4 text-sm leading-6 text-[#666666]">
-              도감으로 이동해 보유한 카드팩을 열고 새로운 포켓몬 카드를 확인해보세요.
-            </p>
-
-            <button
-              type="button"
-              onClick={handleMoveToPokedex}
-              className="mt-8 h-12 w-full rounded-xl bg-[var(--color-primary)] text-base font-bold text-[var(--color-base-3)] transition hover:opacity-80"
-            >
-              도감으로 이동
-            </button>
-          </div>
-        </div>
-      )}
     </>
   );
 }

--- a/src/app/(main)/home/_components/TrainerStatusBar.tsx
+++ b/src/app/(main)/home/_components/TrainerStatusBar.tsx
@@ -47,10 +47,9 @@ export default function TrainerStatusBar({
               type="button"
               onClick={handleMoveToPokedex}
               disabled={!hasCardPack}
-              aria-describedby={hasCardPack ? 'card-pack-tooltip' : undefined}
               className="cursor-pointer text-[#E0E0E0] transition hover:text-[var(--color-base-3)] disabled:hover:text-[#E0E0E0]"
             >
-              보유 카드팩 <strong className="text-[#FFF]">{cardPackCount}</strong> 개
+              보유 카드팩 <strong className="text-[var(--color-base-3)]">{cardPackCount}</strong> 개
             </button>
             {hasCardPack && (
               <span

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -246,3 +246,13 @@ body {
     transform: translateX(110%);
   }
 }
+
+/* overflow-y-auto 속성 */
+.scrollbar-hide {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+
+.scrollbar-hide::-webkit-scrollbar {
+  display: none;
+}

--- a/src/shared/components/pokemon/PokemonDetailModal.tsx
+++ b/src/shared/components/pokemon/PokemonDetailModal.tsx
@@ -22,32 +22,32 @@ export default function PokemonDetailModal({ pokemon, isOpen, onClose }: Pokemon
   const mainType = pokemon.types[0];
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 px-4">
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-[var(--color-base-0)]/60 px-4">
       {/* 뒤에 배경 흐리게 */}
-      <article className="relative grid w-[800px] grid-cols-[240px_1fr] gap-15 rounded-[20px] border-4 border-[#999999] bg-[var(--color-secondary-2)] p-8">
+      <article className="relative grid w-[800px] grid-cols-[240px_1fr] gap-15 rounded-[20px] border-4 border-[#999999] bg-[var(--color-secondary-2)] p-6">
         <button
           type="button"
           aria-label="닫기"
           onClick={onClose}
-          className="absolute top-6 right-6 text-[#999999] transition"
+          className="absolute top-6 right-6 z-20 text-[#999999] transition"
         >
           <X size={36} strokeWidth={1.8} />
         </button>
 
         {/* 포켓몬 카드 뒷면 */}
         <div className="flex h-[390px] w-[260px] items-center justify-center self-center rounded-[12px] bg-[var(--color-secondary-2)] p-3 shadow-[0_0_16px_rgba(0,0,0,0.18)]">
-          <div className="bg-gradient-primary relative flex h-full w-full items-center justify-center overflow-hidden rounded-sm">
-            <div className="absolute inset-2 border-4 border-[var(--color-secondary-2)]" />
-            <div className="relative flex h-28 w-28 items-center justify-center rounded-full bg-[var(--color-secondary-2)]/60">
-              <div className="bg-gradient-primary absolute h-4 w-28" />
-              <div className="bg-gradient-primary z-10 flex h-12 w-12 items-center justify-center rounded-full">
-                <div className="h-6 w-6 rounded-full bg-[var(--color-secondary-2)]/70" />
-              </div>
-            </div>
+          <div className="relative flex h-full w-full items-center justify-center overflow-hidden rounded-sm">
+            <Image
+              src={`/images/pokemon-cards/${pokemon.dexId}.png`}
+              alt={`${pokemon.koName} 카드`}
+              width={260}
+              height={390}
+              className="h-full w-full object-cover"
+            />
           </div>
         </div>
 
-        <section className="h-[390px] self-center overflow-y-auto">
+        <section className="scrollbar-hide h-[390px] self-center overflow-y-auto pr-6">
           <div className="flex items-end gap-2">
             <h2 className="text-3xl font-bold text-[var(--color-base-0)]">{pokemon.koName}</h2>
             <span className="pb-1 text-base font-bold text-[#AAAAAA]">#{String(pokemon.dexId).padStart(3, '0')}</span>


### PR DESCRIPTION
# Pull Request

## 🎯 작업 내용

<!-- 무엇을 했는지 한 줄로 요약 -->
카드팩 안내 툴팁 및 포켓몬 상세 정보 모달 UI를 조정했습니다.

## 📌 작업 배경

<!-- 왜 이 작업이 필요했는지 -->
카드팩을 보유한 상태에서 사용자가 다음 행동을 더 직관적으로 이해할 수 있도록 안내 방식을 개선했습니다.

또한 포켓몬 상세 정보 모달에서 설명이나 특성 문구가 길어질 경우 스크롤바가 닫기 버튼과 겹쳐 보이는 문제가 있어, 스크롤 UI와 카드 표시 방식을 함께 조정했습니다.

## 🔨 구현 내용

<!-- 주요 변경사항을 간략히 나열 -->

#### Added (추가)

- 포켓몬 상세 모달 스크롤바 숨김 유틸 클래스 추가

#### Changed (변경)

- 카드팩 안내 툴팁 크기와 위치 조정
- 포켓몬 상세 모달의 기본 카드 뒷면 UI를 실제 카드 이미지로 변경
- 포켓몬 상세 모달 내부 여백 및 닫기 버튼 z-index 조정
- 상세 정보 영역에 스크롤 가능 상태는 유지하되 스크롤바는 숨기도록 조정


#### Fixed (수정)

- 포켓몬 설명/특성 문구가 길어질 때 스크롤바가 닫기 버튼과 겹쳐 보이는 문제 수정
- 카드팩 안내 모달 대신 툴팁과 도감 이동으로 UX 흐름 단순화

## 📸 결과물

<!-- 스크린샷 또는 동작 화면 -->
- 툴팁 (카드 팩 열기 전)
<img width="1161" height="134" alt="스크린샷 2026-05-19 오후 12 16 43" src="https://github.com/user-attachments/assets/e6ff7775-a757-4ad9-bc3c-c0897a907a41" />


- 툴팁 (카드 팩 연 후)
<img width="1156" height="112" alt="스크린샷 2026-05-19 오후 12 20 00" src="https://github.com/user-attachments/assets/de4fd4fe-eb2f-4f0d-b601-9c4e07a3934b" />


- 상세 정보 모달창
<img width="834" height="474" alt="스크린샷 2026-05-19 오후 12 17 15" src="https://github.com/user-attachments/assets/6d8b5f60-8499-456f-8e0c-6e8603c058de" />

## 🧪 테스트

<!-- 어떻게 테스트했는지 -->

- [X] 카드팩 보유 시 홈 status bar에 안내 툴팁 표시 확인
- [X] 카드팩 버튼 클릭 시 도감 페이지로 이동 확인
- [X] 카드팩 미보유 시 버튼 비활성화 확인
- [X] 포켓몬 상세 모달에서 카드 이미지 정상 표시 확인
- [X] 설명/특성 문구가 긴 포켓몬에서도 스크롤바 겹침 문제가 없는지 확인
- [X] `corepack pnpm lint`
- [X] `corepack pnpm build`

## 💬 리뷰 요청사항

<!-- 특히 봐주셨으면 하는 부분 -->

-

## 🔗 관련 링크

<!-- 이슈, 문서, 디자인 등 -->

- Closes #36
