### PR TITLE
Feat: 포켓몬 데이터 seed script 추가 (#50)

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "prepare": "husky",
     "test": "vitest run",
     "generate:cards": "node scripts/generate-pokemon-cards.mjs",
-    "generate:cards:force": "node scripts/generate-pokemon-cards.mjs --force"
+    "generate:cards:force": "node scripts/generate-pokemon-cards.mjs --force",
+    "seed:game-data": "tsx scripts/seed-game-data.ts"
   },
   "lint-staged": {
     "**/*.{ts,tsx,js,jsx}": [
@@ -54,6 +55,7 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@vitejs/plugin-react": "^6.0.1",
+    "dotenv": "^17.4.2",
     "eslint": "^9",
     "eslint-config-next": "16.2.4",
     "eslint-config-prettier": "^10.1.8",
@@ -62,6 +64,7 @@
     "prettier": "^3.8.3",
     "prettier-plugin-tailwindcss": "^0.7.2",
     "tailwindcss": "^4",
+    "tsx": "^4.22.4",
     "typescript": "^5",
     "vitest": "^4.1.6"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,7 +77,10 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^6.0.1
-        version: 6.0.1(vite@8.0.12(@types/node@20.19.39)(jiti@2.6.1)(yaml@2.8.3))
+        version: 6.0.1(vite@8.0.12(@types/node@20.19.39)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.8.3))
+      dotenv:
+        specifier: ^17.4.2
+        version: 17.4.2
       eslint:
         specifier: ^9
         version: 9.39.4(jiti@2.6.1)
@@ -102,12 +105,15 @@ importers:
       tailwindcss:
         specifier: ^4
         version: 4.2.4
+      tsx:
+        specifier: ^4.22.4
+        version: 4.22.4
       typescript:
         specifier: ^5
         version: 5.9.3
       vitest:
         specifier: ^4.1.6
-        version: 4.1.6(@types/node@20.19.39)(vite@8.0.12(@types/node@20.19.39)(jiti@2.6.1)(yaml@2.8.3))
+        version: 4.1.6(@types/node@20.19.39)(vite@8.0.12(@types/node@20.19.39)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.8.3))
 
 packages:
 
@@ -190,6 +196,162 @@ packages:
 
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+
+  '@esbuild/aix-ppc64@0.28.0':
+    resolution: {integrity: sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.28.0':
+    resolution: {integrity: sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.28.0':
+    resolution: {integrity: sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.0':
+    resolution: {integrity: sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.28.0':
+    resolution: {integrity: sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.0':
+    resolution: {integrity: sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.28.0':
+    resolution: {integrity: sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.0':
+    resolution: {integrity: sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.28.0':
+    resolution: {integrity: sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.0':
+    resolution: {integrity: sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.28.0':
+    resolution: {integrity: sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.0':
+    resolution: {integrity: sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.28.0':
+    resolution: {integrity: sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.0':
+    resolution: {integrity: sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.28.0':
+    resolution: {integrity: sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.0':
+    resolution: {integrity: sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.28.0':
+    resolution: {integrity: sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.28.0':
+    resolution: {integrity: sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.28.0':
+    resolution: {integrity: sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.28.0':
+    resolution: {integrity: sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.28.0':
+    resolution: {integrity: sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.28.0':
+    resolution: {integrity: sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.28.0':
+    resolution: {integrity: sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.0':
+    resolution: {integrity: sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
 
   '@eslint-community/eslint-utils@4.9.1':
     resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
@@ -1372,6 +1534,10 @@ packages:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
 
+  dotenv@17.4.2:
+    resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
+    engines: {node: '>=12'}
+
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
@@ -1427,6 +1593,11 @@ packages:
   es-to-primitive@1.3.0:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
+
+  esbuild@0.28.0:
+    resolution: {integrity: sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
@@ -2567,6 +2738,11 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
+  tsx@4.22.4:
+    resolution: {integrity: sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
@@ -2899,6 +3075,84 @@ snapshots:
   '@emnapi/wasi-threads@1.2.1':
     dependencies:
       tslib: 2.8.1
+    optional: true
+
+  '@esbuild/aix-ppc64@0.28.0':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/android-arm@0.28.0':
+    optional: true
+
+  '@esbuild/android-x64@0.28.0':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.0':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.0':
+    optional: true
+
+  '@esbuild/linux-ia32@0.28.0':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.28.0':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.0':
+    optional: true
+
+  '@esbuild/linux-x64@0.28.0':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.28.0':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.28.0':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/sunos-x64@0.28.0':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/win32-ia32@0.28.0':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.0':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4(jiti@2.6.1))':
@@ -3586,10 +3840,10 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
-  '@vitejs/plugin-react@6.0.1(vite@8.0.12(@types/node@20.19.39)(jiti@2.6.1)(yaml@2.8.3))':
+  '@vitejs/plugin-react@6.0.1(vite@8.0.12(@types/node@20.19.39)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.8.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
-      vite: 8.0.12(@types/node@20.19.39)(jiti@2.6.1)(yaml@2.8.3)
+      vite: 8.0.12(@types/node@20.19.39)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.8.3)
 
   '@vitest/expect@4.1.6':
     dependencies:
@@ -3600,13 +3854,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.6(vite@8.0.12(@types/node@20.19.39)(jiti@2.6.1)(yaml@2.8.3))':
+  '@vitest/mocker@4.1.6(vite@8.0.12(@types/node@20.19.39)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 4.1.6
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.12(@types/node@20.19.39)(jiti@2.6.1)(yaml@2.8.3)
+      vite: 8.0.12(@types/node@20.19.39)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.8.3)
 
   '@vitest/pretty-format@4.1.6':
     dependencies:
@@ -3882,6 +4136,8 @@ snapshots:
     dependencies:
       esutils: 2.0.3
 
+  dotenv@17.4.2: {}
+
   dunder-proto@1.0.1:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -4003,6 +4259,35 @@ snapshots:
       is-callable: 1.2.7
       is-date-object: 1.1.0
       is-symbol: 1.1.1
+
+  esbuild@0.28.0:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.0
+      '@esbuild/android-arm': 0.28.0
+      '@esbuild/android-arm64': 0.28.0
+      '@esbuild/android-x64': 0.28.0
+      '@esbuild/darwin-arm64': 0.28.0
+      '@esbuild/darwin-x64': 0.28.0
+      '@esbuild/freebsd-arm64': 0.28.0
+      '@esbuild/freebsd-x64': 0.28.0
+      '@esbuild/linux-arm': 0.28.0
+      '@esbuild/linux-arm64': 0.28.0
+      '@esbuild/linux-ia32': 0.28.0
+      '@esbuild/linux-loong64': 0.28.0
+      '@esbuild/linux-mips64el': 0.28.0
+      '@esbuild/linux-ppc64': 0.28.0
+      '@esbuild/linux-riscv64': 0.28.0
+      '@esbuild/linux-s390x': 0.28.0
+      '@esbuild/linux-x64': 0.28.0
+      '@esbuild/netbsd-arm64': 0.28.0
+      '@esbuild/netbsd-x64': 0.28.0
+      '@esbuild/openbsd-arm64': 0.28.0
+      '@esbuild/openbsd-x64': 0.28.0
+      '@esbuild/openharmony-arm64': 0.28.0
+      '@esbuild/sunos-x64': 0.28.0
+      '@esbuild/win32-arm64': 0.28.0
+      '@esbuild/win32-ia32': 0.28.0
+      '@esbuild/win32-x64': 0.28.0
 
   escalade@3.2.0: {}
 
@@ -5216,6 +5501,12 @@ snapshots:
 
   tslib@2.8.1: {}
 
+  tsx@4.22.4:
+    dependencies:
+      esbuild: 0.28.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
@@ -5316,7 +5607,7 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  vite@8.0.12(@types/node@20.19.39)(jiti@2.6.1)(yaml@2.8.3):
+  vite@8.0.12(@types/node@20.19.39)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.8.3):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -5325,14 +5616,16 @@ snapshots:
       tinyglobby: 0.2.16
     optionalDependencies:
       '@types/node': 20.19.39
+      esbuild: 0.28.0
       fsevents: 2.3.3
       jiti: 2.6.1
+      tsx: 4.22.4
       yaml: 2.8.3
 
-  vitest@4.1.6(@types/node@20.19.39)(vite@8.0.12(@types/node@20.19.39)(jiti@2.6.1)(yaml@2.8.3)):
+  vitest@4.1.6(@types/node@20.19.39)(vite@8.0.12(@types/node@20.19.39)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.6
-      '@vitest/mocker': 4.1.6(vite@8.0.12(@types/node@20.19.39)(jiti@2.6.1)(yaml@2.8.3))
+      '@vitest/mocker': 4.1.6(vite@8.0.12(@types/node@20.19.39)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.8.3))
       '@vitest/pretty-format': 4.1.6
       '@vitest/runner': 4.1.6
       '@vitest/snapshot': 4.1.6
@@ -5349,7 +5642,7 @@ snapshots:
       tinyexec: 1.1.1
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 8.0.12(@types/node@20.19.39)(jiti@2.6.1)(yaml@2.8.3)
+      vite: 8.0.12(@types/node@20.19.39)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.19.39

--- a/scripts/seed-game-data.ts
+++ b/scripts/seed-game-data.ts
@@ -1,0 +1,135 @@
+import { createClient } from '@supabase/supabase-js';
+import dotenv from 'dotenv';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { z } from 'zod';
+import { PokemonData } from '../src/shared/types/pokemon';
+
+dotenv.config({ path: '.env.local' });
+
+const SeedPokemonData = PokemonData.extend({
+  isLegendary: z.boolean().optional(),
+});
+
+const PokemonJsonByDexIdSchema = z.record(z.string(), SeedPokemonData);
+
+type PokemonJson = z.infer<typeof SeedPokemonData>;
+type PokemonJsonByDexId = Record<string, PokemonJson>;
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!supabaseUrl || !serviceRoleKey) {
+  throw new Error('NEXT_PUBLIC_SUPABASE_URL 또는 SUPABASE_SERVICE_ROLE_KEY가 없습니다.');
+}
+
+const supabase = createClient(supabaseUrl, serviceRoleKey, {
+  auth: {
+    persistSession: false,
+  },
+});
+
+async function readJsonFile<T>(filePath: string): Promise<T> {
+  const absolutePath = path.join(process.cwd(), filePath);
+  const file = await fs.readFile(absolutePath, 'utf-8');
+
+  return JSON.parse(file) as T;
+}
+
+function parseWithSchema<T>(schema: z.ZodType<T>, data: unknown, label: string): T {
+  const result = schema.safeParse(data);
+
+  if (!result.success) {
+    const detail = result.error.issues
+      .slice(0, 5)
+      .map((issue) => `${issue.path.join('.')}: ${issue.message}`)
+      .join('\n');
+
+    throw new Error(`${label} 검증 실패\n${detail}`);
+  }
+
+  return result.data;
+}
+
+function getUniqueTypes(pokemons: PokemonJson[]) {
+  const typeIds = new Set<string>();
+
+  pokemons.forEach((pokemon) => {
+    pokemon.types.forEach((type) => typeIds.add(type));
+  });
+
+  return Array.from(typeIds).map((typeId) => ({
+    id: typeId,
+    ko_name: typeId,
+  }));
+}
+
+async function upsertTypes(pokemons: PokemonJson[]) {
+  const rows = getUniqueTypes(pokemons);
+
+  const { error } = await supabase.from('types').upsert(rows, {
+    onConflict: 'id',
+  });
+
+  if (error) {
+    throw new Error(`types seed 실패: ${error.message}`);
+  }
+
+  console.log(`types seed 완료: ${rows.length}개`);
+}
+
+async function upsertPokemonSpecies(pokemons: PokemonJson[]) {
+  const rows = pokemons.map((pokemon) => ({
+    dex_id: pokemon.dexId,
+    ko_name: pokemon.koName,
+    en_name: pokemon.enName,
+
+    type1_id: pokemon.types[0],
+    type2_id: pokemon.types[1] ?? null,
+
+    // 현재 pokemon_species 테이블은 speed만 base_spd 컬럼으로 관리한다.
+    base_hp: pokemon.baseStats.hp,
+    base_atk: pokemon.baseStats.attack,
+    base_def: pokemon.baseStats.defense,
+    base_spd: pokemon.baseStats.speed,
+
+    generation: pokemon.generation,
+    evolution_stage: pokemon.evolutionStage,
+    is_legendary: pokemon.isLegendary ?? false,
+
+    sprite_url: pokemon.spriteUrl,
+    artwork_url: pokemon.artworkUrl,
+
+    height: pokemon.height,
+    weight: pokemon.weight,
+    category: pokemon.category,
+    flavor_text: pokemon.flavorText,
+    ability: pokemon.ability,
+  }));
+
+  const { error } = await supabase.from('pokemon_species').upsert(rows, {
+    onConflict: 'dex_id',
+  });
+
+  if (error) {
+    throw new Error(`pokemon_species seed 실패: ${error.message}`);
+  }
+
+  console.log(`pokemon_species seed 완료: ${rows.length}개`);
+}
+
+async function main() {
+  const rawPokemonMap = await readJsonFile<unknown>('data/pokemon.json');
+  const pokemonMap: PokemonJsonByDexId = parseWithSchema(PokemonJsonByDexIdSchema, rawPokemonMap, 'data/pokemon.json');
+  const pokemons = Object.values(pokemonMap);
+
+  await upsertTypes(pokemons);
+  await upsertPokemonSpecies(pokemons);
+
+  console.log('pokemon_species seed 테스트 완료');
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/src/app/(main)/home/page.tsx
+++ b/src/app/(main)/home/page.tsx
@@ -1,76 +1,20 @@
-'use client';
-
-// 홈 페이지 — 트레이너 데이터 확인 후 배너, 상태바, 액션 카드 렌더링
-
-import { storageKeys } from '@/app/(main)/(start)/_constants/key';
-import type { TrainerData } from '@/app/(main)/(start)/_types/trainer';
 import HomeActionCards from '@/app/(main)/home/_components/HomeActionCards';
 import HomeBanner from '@/app/(main)/home/_components/HomeBanner';
 import TrainerStatusBar from '@/app/(main)/home/_components/TrainerStatusBar';
-import { useTowerProgress } from '@/shared/hooks/useTowerProgress';
-import { useRouter } from 'next/navigation';
-import { useEffect, useMemo, useSyncExternalStore } from 'react';
 import { pokemonCatalog } from '@/shared/data/pokemon-catalog';
 import HomeHeader from '@/shared/components/HomeHeader';
+import { redirect } from 'next/navigation';
+import { getTrainerSummary } from '@/entities/trainer/api/trainerApi';
 
-const subscribeTrainerStorage = (onStoreChange: () => void) => {
-  window.addEventListener('storage', onStoreChange);
-  window.addEventListener('trainer-data-updated', onStoreChange);
-  return () => {
-    window.removeEventListener('storage', onStoreChange);
-    window.removeEventListener('trainer-data-updated', onStoreChange);
-  };
-};
+export default async function HomePage() {
+  const trainer = await getTrainerSummary();
 
-const getTrainerSnapshot = () => {
-  try {
-    return localStorage.getItem(storageKeys.TRAINER_DATA);
-  } catch (error) {
-    console.error(error);
-    return null;
+  if (!trainer) {
+    redirect('/');
   }
-};
 
-const getServerTrainerSnapshot = () => undefined;
-
-export default function HomePage() {
-  const router = useRouter();
-  const { progress } = useTowerProgress();
-
-  const trainerData = useSyncExternalStore(subscribeTrainerStorage, getTrainerSnapshot, getServerTrainerSnapshot);
-
-  const parsedTrainerData = useMemo(() => {
-    if (trainerData === undefined || trainerData === null) {
-      return trainerData;
-    }
-
-    try {
-      return JSON.parse(trainerData) as TrainerData;
-    } catch (error) {
-      console.error(error);
-      return null;
-    }
-  }, [trainerData]);
-
-  const hasValidTrainer =
-    parsedTrainerData !== undefined &&
-    parsedTrainerData !== null &&
-    typeof parsedTrainerData.nickname === 'string' &&
-    parsedTrainerData.nickname.trim().length > 0;
-
-  useEffect(() => {
-    // /home 직접 접근 시 트레이너 데이터가 없으면 /로 리다이렉트
-    if (parsedTrainerData === null) {
-      router.replace('/');
-    }
-  }, [parsedTrainerData, router]);
-
-  if (!hasValidTrainer) return null;
-
-  // 홈 화면 카드 섹션에서 보여줄 포유 포켓몬 갯수 관리 상수
-  const selectedPokemonCount = parsedTrainerData.selectedPokemons?.length ?? 0;
   const totalPokemonCount = Object.keys(pokemonCatalog).length;
-  const battleRecord = parsedTrainerData.battleRecord ?? { wins: 0, losses: 0 };
+  const battleRecord = trainer.battleRecord ?? { wins: 0, losses: 0 };
 
   return (
     <main className="flex min-h-dvh flex-col overflow-x-hidden bg-[var(--color-base-3)] text-[var(--color-base-1)]">
@@ -78,12 +22,12 @@ export default function HomePage() {
       <div className="mx-auto flex w-full max-w-6xl flex-1 flex-col px-4 pt-14 pb-8">
         <HomeBanner />
         <TrainerStatusBar
-          trainerName={parsedTrainerData.nickname}
-          cardPackCount={parsedTrainerData.cardPackCount ?? 0}
-          towerProgress={progress.currentFloor}
+          trainerName={trainer.nickname}
+          cardPackCount={trainer.cardPackCount ?? 0}
+          towerProgress={trainer.currentFloor}
           battleRecord={`${battleRecord.wins}승 ${battleRecord.losses}패`}
         />
-        <HomeActionCards selectedPokemonCount={selectedPokemonCount} totalPokemonCount={totalPokemonCount} />
+        <HomeActionCards selectedPokemonCount={trainer.ownedPokemonCount} totalPokemonCount={totalPokemonCount} />
       </div>
 
       <footer className="pb-6 text-center text-sm text-[#888888]">© 2026 Team 로켓단. All rights reserved.</footer>


### PR DESCRIPTION
# Pull Request

## 🎯 작업 내용

<!-- 무엇을 했는지 한 줄로 요약 -->
pokemon.json 데이터를 Supabase pokemon_species 테이블에 저장하기 위한 seed 스크립트를 추가했습니다.

## 📌 작업 배경

<!-- 왜 이 작업이 필요했는지 -->
기존 포켓몬 데이터는 로컬 data/pokemon.json을 기반으로 사용되고 있었습니다.
게임 데이터 관리 기준을 Supabase DB로 옮기기 위해, 로컬 JSON 데이터를 DB 테이블 구조에 맞게 변환하여 저장하는 seed 흐름이 필요했습니다.

## 🔨 구현 내용

<!-- 주요 변경사항을 간략히 나열 -->

#### Added (추가)

- scripts/seed-game-data.ts seed 스크립트 추가
- data/pokemon.json 데이터를 pokemon_species 테이블 컬럼 구조에 맞게 매핑
- types 테이블에 포켓몬 타입 데이터를 우선 저장하는 흐름 추가
- pokemon_species 데이터를 dex_id 기준으로 upsert 처리
- seed 스크립트 실행을 위한 package script 및 관련 dev dependency 추가

 
#### Changed (변경)

-

#### Fixed (수정)

-

## 📸 결과물

<!-- 스크린샷 또는 동작 화면 -->

- script 정상 작동
<img width="607" height="101" alt="스크린샷 2026-06-02 오후 2 23 49" src="https://github.com/user-attachments/assets/c58ca7c2-41b8-4956-a036-56b4c239d58a" />


- 테이블에 정상 삽입 완료
<img width="1188" height="308" alt="스크린샷 2026-06-02 오후 2 24 25" src="https://github.com/user-attachments/assets/65fe69a7-25c6-4f36-b54f-e93a8fadce8e" />


## 🧪 테스트

<!-- 어떻게 테스트했는지 -->

- [X] corepack pnpm seed:game-data
- [X] Supabase pokemon_species 테이블에 포켓몬 데이터 저장 확인

## 💬 리뷰 요청사항

<!-- 특히 봐주셨으면 하는 부분 -->

- 일단 pokemon.json에 존재하는 데이터들을 script화 하여 적용한 것입니다. 차후엔 api에서 정보를 읽고 불러오는 것으로 변경할 예정입니다

## 🔗 관련 링크

<!-- 이슈, 문서, 디자인 등 -->

- Closes #50


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 게임 데이터 초기화 스크립트 추가로 포켓몬 정보 및 타입 데이터를 데이터베이스에 로드 가능

* **Improvements**
  * 홈 페이지의 데이터 로딩 방식 개선으로 사용자 정보와 진행 상황을 더 빠르게 표시

* **Chores**
  * 개발 도구 의존성 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->