### PR TITLE
Feat/#53/pokeapi static data

### DIFF
--- a/scripts/seed-game-data.ts
+++ b/scripts/seed-game-data.ts
@@ -94,6 +94,8 @@ const PokemonSpeciesRow = z.object({
   base_hp: z.number().int(),
   base_atk: z.number().int(),
   base_def: z.number().int(),
+  base_sp_atk: z.number().int(),
+  base_sp_def: z.number().int(),
   base_spd: z.number().int(),
   generation: z.number().int(),
   evolution_stage: z.number().int(),
@@ -318,13 +320,21 @@ async function fetchMainAbility(pokemon: any) {
   return value;
 }
 
+const pokemonCache = new Map<number, any>();
+
+async function fetchPokemon(dexId: number) {
+  const cached = pokemonCache.get(dexId);
+  if (cached) return cached;
+
+  const pokemon = await fetchPokeApi<any>(`/pokemon/${dexId}`);
+  pokemonCache.set(dexId, pokemon);
+  return pokemon;
+}
+
 // PokeAPI의 pokemon + pokemon-species 응답을 pokemon_species row로 변환한다.
 // 외부 API 응답 전체가 아니라 앱에서 필요한 필드만 선별해서 저장한다.
 async function fetchPokemonSpeciesRow(dexId: number): Promise<PokemonSpeciesRow> {
-  const [pokemon, species] = await Promise.all([
-    fetchPokeApi<any>(`/pokemon/${dexId}`),
-    fetchPokeApi<any>(`/pokemon-species/${dexId}`),
-  ]);
+  const [pokemon, species] = await Promise.all([fetchPokemon(dexId), fetchPokeApi<any>(`/pokemon-species/${dexId}`)]);
 
   return PokemonSpeciesRow.parse({
     dex_id: dexId,
@@ -335,6 +345,8 @@ async function fetchPokemonSpeciesRow(dexId: number): Promise<PokemonSpeciesRow>
     base_hp: findStat(pokemon.stats, 'hp'),
     base_atk: findStat(pokemon.stats, 'attack'),
     base_def: findStat(pokemon.stats, 'defense'),
+    base_sp_atk: findStat(pokemon.stats, 'special-attack'),
+    base_sp_def: findStat(pokemon.stats, 'special-defense'),
     base_spd: findStat(pokemon.stats, 'speed'),
     generation: parseGeneration(species.generation.name),
     evolution_stage: await fetchEvolutionStage(species),
@@ -390,7 +402,7 @@ async function fetchLearnsetRows(dexIds: number[]): Promise<LearnsetRow[]> {
   const uniqueKeys = new Set<string>();
 
   for (const dexId of dexIds) {
-    const pokemon = await fetchPokeApi<any>(`/pokemon/${dexId}`);
+    const pokemon = await fetchPokemon(dexId);
 
     for (const moveEntry of pokemon.moves) {
       const versionDetail = findMoveVersionDetail(moveEntry);

--- a/scripts/seed-game-data.ts
+++ b/scripts/seed-game-data.ts
@@ -1,132 +1,474 @@
 import { createClient } from '@supabase/supabase-js';
 import dotenv from 'dotenv';
-import fs from 'node:fs/promises';
-import path from 'node:path';
 import { z } from 'zod';
-import { PokemonData } from '../src/shared/types/pokemon';
 
 dotenv.config({ path: '.env.local' });
 
-const SeedPokemonData = PokemonData.extend({
-  isLegendary: z.boolean().optional(),
-});
+const POKEAPI_BASE_URL = 'https://pokeapi.co/api/v2';
+const MAX_DEX_ID = 809;
+const REQUEST_DELAY_MS = 120;
+const UPSERT_CHUNK_SIZE = 500;
 
-const PokemonJsonByDexIdSchema = z.record(z.string(), SeedPokemonData);
+const POKEMON_TYPE_IDS = [
+  'normal',
+  'fire',
+  'water',
+  'electric',
+  'grass',
+  'ice',
+  'fighting',
+  'poison',
+  'ground',
+  'flying',
+  'psychic',
+  'bug',
+  'rock',
+  'ghost',
+  'dragon',
+  'dark',
+  'steel',
+  'fairy',
+] as const;
 
-type PokemonJson = z.infer<typeof SeedPokemonData>;
-type PokemonJsonByDexId = Record<string, PokemonJson>;
+const POKEMON_TYPE_ID_SET = new Set<string>(POKEMON_TYPE_IDS);
+
+// 7세대 데이터를 우선 사용하고, 없으면 이전 세대 버전 그룹으로 내려간다.
+const VERSION_GROUP_PRIORITY = [
+  'ultra-sun-ultra-moon',
+  'sun-moon',
+  'omega-ruby-alpha-sapphire',
+  'x-y',
+  'black-2-white-2',
+  'black-white',
+  'heartgold-soulsilver',
+  'platinum',
+  'diamond-pearl',
+  'emerald',
+  'firered-leafgreen',
+  'ruby-sapphire',
+  'crystal',
+  'gold-silver',
+  'yellow',
+  'red-blue',
+];
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
 const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+const FETCH_BATCH_SIZE = 10;
 
 if (!supabaseUrl || !serviceRoleKey) {
   throw new Error('NEXT_PUBLIC_SUPABASE_URL 또는 SUPABASE_SERVICE_ROLE_KEY가 없습니다.');
 }
 
+// 운영 DB에 실수로 seed하는 일을 줄이기 위한 안전장치다.
+if (process.env.CONFIRM_SEED_GAME_DATA !== 'true') {
+  throw new Error('CONFIRM_SEED_GAME_DATA=true 설정 후 실행하세요.');
+}
+
+// seed script는 서버/로컬 CLI에서만 실행한다.
+// service role key는 클라이언트 코드에 절대 노출하지 않는다.
 const supabase = createClient(supabaseUrl, serviceRoleKey, {
   auth: {
     persistSession: false,
   },
 });
 
-async function readJsonFile<T>(filePath: string): Promise<T> {
-  const absolutePath = path.join(process.cwd(), filePath);
-  const file = await fs.readFile(absolutePath, 'utf-8');
+const TypeRow = z.object({
+  id: z.string(),
+  ko_name: z.string(),
+});
 
-  return JSON.parse(file) as T;
+const TypeChartRow = z.object({
+  attack_type_id: z.string(),
+  defense_type_id: z.string(),
+  multiplier: z.number(),
+});
+
+const PokemonSpeciesRow = z.object({
+  dex_id: z.number().int(),
+  ko_name: z.string(),
+  en_name: z.string(),
+  type1_id: z.string(),
+  type2_id: z.string().nullable(),
+  base_hp: z.number().int(),
+  base_atk: z.number().int(),
+  base_def: z.number().int(),
+  base_spd: z.number().int(),
+  generation: z.number().int(),
+  evolution_stage: z.number().int(),
+  is_legendary: z.boolean(),
+  sprite_url: z.string().nullable(),
+  artwork_url: z.string().nullable(),
+  height: z.number(),
+  weight: z.number(),
+  category: z.string(),
+  flavor_text: z.string(),
+  ability: z.object({
+    name: z.string(),
+    description: z.string(),
+  }),
+});
+
+const MoveRow = z.object({
+  id: z.string(),
+  ko_name: z.string(),
+  en_name: z.string(),
+  type_id: z.string(),
+  damage_class: z.enum(['physical', 'special', 'status']),
+  power: z.number().int(),
+  accuracy: z.number().int(),
+  pp: z.number().int(),
+  effect_text: z.string(),
+  status_effect_chance: z.number().int(),
+});
+
+const LearnsetRow = z.object({
+  dex_id: z.number().int(),
+  move_id: z.string(),
+  learn_level: z.number().int().min(1),
+});
+
+type TypeRow = z.infer<typeof TypeRow>;
+type TypeChartRow = z.infer<typeof TypeChartRow>;
+type PokemonSpeciesRow = z.infer<typeof PokemonSpeciesRow>;
+type MoveRow = z.infer<typeof MoveRow>;
+type LearnsetRow = z.infer<typeof LearnsetRow>;
+
+const moveCache = new Map<string, any>();
+const abilityCache = new Map<string, { name: string; description: string }>();
+const evolutionStageCache = new Map<string, number>();
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-function parseWithSchema<T>(schema: z.ZodType<T>, data: unknown, label: string): T {
-  const result = schema.safeParse(data);
+// PokeAPI는 seed 시점에만 호출한다.
+// 앱 런타임에서는 Supabase를 단일 데이터 원본으로 사용한다.
+async function fetchPokeApi<T>(pathOrUrl: string): Promise<T> {
+  const url = pathOrUrl.startsWith('http') ? pathOrUrl : `${POKEAPI_BASE_URL}${pathOrUrl}`;
+  const response = await fetch(url);
 
-  if (!result.success) {
-    const detail = result.error.issues
-      .slice(0, 5)
-      .map((issue) => `${issue.path.join('.')}: ${issue.message}`)
-      .join('\n');
-
-    throw new Error(`${label} 검증 실패\n${detail}`);
+  if (!response.ok) {
+    throw new Error(`PokeAPI 요청 실패: ${url} (${response.status})`);
   }
 
-  return result.data;
+  await sleep(REQUEST_DELAY_MS);
+  return response.json() as Promise<T>;
 }
 
-function getUniqueTypes(pokemons: PokemonJson[]) {
-  const typeIds = new Set<string>();
+async function upsertChunked(table: string, rows: unknown[], onConflict: string) {
+  for (let i = 0; i < rows.length; i += UPSERT_CHUNK_SIZE) {
+    const chunk = rows.slice(i, i + UPSERT_CHUNK_SIZE);
+    const { error } = await supabase.from(table).upsert(chunk, { onConflict });
 
-  pokemons.forEach((pokemon) => {
-    pokemon.types.forEach((type) => typeIds.add(type));
-  });
-
-  return Array.from(typeIds).map((typeId) => ({
-    id: typeId,
-    ko_name: typeId,
-  }));
-}
-
-async function upsertTypes(pokemons: PokemonJson[]) {
-  const rows = getUniqueTypes(pokemons);
-
-  const { error } = await supabase.from('types').upsert(rows, {
-    onConflict: 'id',
-  });
-
-  if (error) {
-    throw new Error(`types seed 실패: ${error.message}`);
+    if (error) {
+      throw new Error(`${table} seed 실패: ${error.message}`);
+    }
   }
 
-  console.log(`types seed 완료: ${rows.length}개`);
+  console.log(`${table} seed 완료: ${rows.length}개`);
 }
 
-async function upsertPokemonSpecies(pokemons: PokemonJson[]) {
-  const rows = pokemons.map((pokemon) => ({
-    dex_id: pokemon.dexId,
-    ko_name: pokemon.koName,
-    en_name: pokemon.enName,
+function findLocalizedName(names: any[], fallback: string) {
+  return (
+    names.find((entry) => entry.language.name === 'ko')?.name ??
+    names.find((entry) => entry.language.name === 'en')?.name ??
+    fallback
+  );
+}
 
-    type1_id: pokemon.types[0],
-    type2_id: pokemon.types[1] ?? null,
+function findFlavorText(entries: any[]) {
+  const entry =
+    entries.find((item) => item.language.name === 'ko') ?? entries.find((item) => item.language.name === 'en');
 
-    // 현재 pokemon_species 테이블은 speed만 base_spd 컬럼으로 관리한다.
-    base_hp: pokemon.baseStats.hp,
-    base_atk: pokemon.baseStats.attack,
-    base_def: pokemon.baseStats.defense,
-    base_spd: pokemon.baseStats.speed,
+  return (entry?.flavor_text ?? '').replace(/\f|\n|\r/g, ' ');
+}
 
-    generation: pokemon.generation,
-    evolution_stage: pokemon.evolutionStage,
-    is_legendary: pokemon.isLegendary ?? false,
+function findEffectText(entries: any[]) {
+  const entry = entries.find((item) => item.language.name === 'en');
 
-    sprite_url: pokemon.spriteUrl,
-    artwork_url: pokemon.artworkUrl,
+  return (entry?.short_effect ?? entry?.effect ?? '').replace(/\$effect_chance/g, 'effect chance');
+}
 
-    height: pokemon.height,
-    weight: pokemon.weight,
-    category: pokemon.category,
-    flavor_text: pokemon.flavorText,
-    ability: pokemon.ability,
-  }));
+function findGenus(genera: any[]) {
+  return (
+    genera.find((entry) => entry.language.name === 'ko')?.genus ??
+    genera.find((entry) => entry.language.name === 'en')?.genus ??
+    ''
+  );
+}
 
-  const { error } = await supabase.from('pokemon_species').upsert(rows, {
-    onConflict: 'dex_id',
-  });
+function findStat(stats: any[], statName: string) {
+  const stat = stats.find((entry) => entry.stat.name === statName);
+  return stat?.base_stat ?? 1;
+}
 
-  if (error) {
-    throw new Error(`pokemon_species seed 실패: ${error.message}`);
+function parseGeneration(generationName: string) {
+  const roman = generationName.replace('generation-', '');
+
+  const generationMap: Record<string, number> = {
+    i: 1,
+    ii: 2,
+    iii: 3,
+    iv: 4,
+    v: 5,
+    vi: 6,
+    vii: 7,
+  };
+
+  return generationMap[roman] ?? 1;
+}
+
+async function fetchTypes(): Promise<TypeRow[]> {
+  const rows = await Promise.all(
+    POKEMON_TYPE_IDS.map(async (typeId) => {
+      const type = await fetchPokeApi<any>(`/type/${typeId}`);
+
+      return TypeRow.parse({
+        id: typeId,
+        ko_name: findLocalizedName(type.names, typeId),
+      });
+    }),
+  );
+
+  return rows;
+}
+
+async function fetchTypeCharts(): Promise<TypeChartRow[]> {
+  const rows: TypeChartRow[] = [];
+
+  for (const attackTypeId of POKEMON_TYPE_IDS) {
+    const type = await fetchPokeApi<any>(`/type/${attackTypeId}`);
+
+    const multiplierByDefenseType = new Map<string, number>();
+    POKEMON_TYPE_IDS.forEach((defenseTypeId) => multiplierByDefenseType.set(defenseTypeId, 1));
+
+    type.damage_relations.double_damage_to.forEach((entry: any) => {
+      if (POKEMON_TYPE_ID_SET.has(entry.name)) multiplierByDefenseType.set(entry.name, 2);
+    });
+
+    type.damage_relations.half_damage_to.forEach((entry: any) => {
+      if (POKEMON_TYPE_ID_SET.has(entry.name)) multiplierByDefenseType.set(entry.name, 0.5);
+    });
+
+    type.damage_relations.no_damage_to.forEach((entry: any) => {
+      if (POKEMON_TYPE_ID_SET.has(entry.name)) multiplierByDefenseType.set(entry.name, 0);
+    });
+
+    multiplierByDefenseType.forEach((multiplier, defenseTypeId) => {
+      rows.push(
+        TypeChartRow.parse({
+          attack_type_id: attackTypeId,
+          defense_type_id: defenseTypeId,
+          multiplier,
+        }),
+      );
+    });
   }
 
-  console.log(`pokemon_species seed 완료: ${rows.length}개`);
+  return rows;
+}
+
+function findSpeciesDepth(chainNode: any, targetSpeciesName: string, depth = 1): number | null {
+  if (chainNode.species.name === targetSpeciesName) return depth;
+
+  for (const next of chainNode.evolves_to ?? []) {
+    const found = findSpeciesDepth(next, targetSpeciesName, depth + 1);
+    if (found !== null) return found;
+  }
+
+  return null;
+}
+
+async function fetchEvolutionStage(species: any) {
+  const chainUrl = species.evolution_chain?.url;
+
+  if (!chainUrl) return 1;
+
+  const cached = evolutionStageCache.get(`${chainUrl}:${species.name}`);
+  if (cached) return cached;
+
+  const chain = await fetchPokeApi<any>(chainUrl);
+  const stage = findSpeciesDepth(chain.chain, species.name) ?? 1;
+
+  evolutionStageCache.set(`${chainUrl}:${species.name}`, stage);
+  return stage;
+}
+
+async function fetchMainAbility(pokemon: any) {
+  const mainAbility =
+    pokemon.abilities.find((entry: any) => !entry.is_hidden)?.ability ?? pokemon.abilities[0]?.ability;
+
+  if (!mainAbility) {
+    return { name: '', description: '' };
+  }
+
+  const cached = abilityCache.get(mainAbility.name);
+  if (cached) return cached;
+
+  const ability = await fetchPokeApi<any>(mainAbility.url);
+
+  const value = {
+    name: findLocalizedName(ability.names, mainAbility.name),
+    description: findFlavorText(ability.flavor_text_entries),
+  };
+
+  abilityCache.set(mainAbility.name, value);
+  return value;
+}
+
+// PokeAPI의 pokemon + pokemon-species 응답을 pokemon_species row로 변환한다.
+// 외부 API 응답 전체가 아니라 앱에서 필요한 필드만 선별해서 저장한다.
+async function fetchPokemonSpeciesRow(dexId: number): Promise<PokemonSpeciesRow> {
+  const [pokemon, species] = await Promise.all([
+    fetchPokeApi<any>(`/pokemon/${dexId}`),
+    fetchPokeApi<any>(`/pokemon-species/${dexId}`),
+  ]);
+
+  return PokemonSpeciesRow.parse({
+    dex_id: dexId,
+    ko_name: findLocalizedName(species.names, pokemon.name),
+    en_name: pokemon.name,
+    type1_id: pokemon.types[0].type.name,
+    type2_id: pokemon.types[1]?.type.name ?? null,
+    base_hp: findStat(pokemon.stats, 'hp'),
+    base_atk: findStat(pokemon.stats, 'attack'),
+    base_def: findStat(pokemon.stats, 'defense'),
+    base_spd: findStat(pokemon.stats, 'speed'),
+    generation: parseGeneration(species.generation.name),
+    evolution_stage: await fetchEvolutionStage(species),
+    is_legendary: species.is_legendary,
+    sprite_url: pokemon.sprites.front_default,
+    artwork_url: pokemon.sprites.other?.['official-artwork']?.front_default ?? null,
+    height: pokemon.height / 10,
+    weight: pokemon.weight / 10,
+    category: findGenus(species.genera),
+    flavor_text: findFlavorText(species.flavor_text_entries),
+    ability: await fetchMainAbility(pokemon),
+  });
+}
+
+async function fetchPokemonSpeciesRows(dexIds: number[]) {
+  const rows: PokemonSpeciesRow[] = [];
+
+  for (let i = 0; i < dexIds.length; i += FETCH_BATCH_SIZE) {
+    const batch = dexIds.slice(i, i + FETCH_BATCH_SIZE);
+    const batchRows = await Promise.all(batch.map((dexId) => fetchPokemonSpeciesRow(dexId)));
+
+    rows.push(...batchRows);
+    console.log(`pokemon_species 준비: ${rows.length}/${MAX_DEX_ID}`);
+  }
+
+  return rows;
+}
+
+async function fetchMove(moveId: string) {
+  const cached = moveCache.get(moveId);
+  if (cached) return cached;
+
+  const move = await fetchPokeApi<any>(`/move/${moveId}`);
+  moveCache.set(moveId, move);
+
+  return move;
+}
+
+function findMoveVersionDetail(moveEntry: any) {
+  for (const versionGroup of VERSION_GROUP_PRIORITY) {
+    const detail = moveEntry.version_group_details.find((entry: any) => entry.version_group.name === versionGroup);
+
+    if (detail) return detail;
+  }
+
+  return null;
+}
+
+// learnsets는 포켓몬별 레벨업 기술표다.
+// 유저가 가진 포켓몬의 현재 기술/PP는 owned_pokemon_moves에서 별도로 관리한다.
+async function fetchLearnsetRows(dexIds: number[]): Promise<LearnsetRow[]> {
+  const rows: LearnsetRow[] = [];
+  const uniqueKeys = new Set<string>();
+
+  for (const dexId of dexIds) {
+    const pokemon = await fetchPokeApi<any>(`/pokemon/${dexId}`);
+
+    for (const moveEntry of pokemon.moves) {
+      const versionDetail = findMoveVersionDetail(moveEntry);
+
+      if (!versionDetail || versionDetail.move_learn_method.name !== 'level-up') {
+        continue;
+      }
+
+      const learnLevel = Math.max(versionDetail.level_learned_at ?? 1, 1);
+
+      const row = LearnsetRow.parse({
+        dex_id: dexId,
+        move_id: moveEntry.move.name,
+        learn_level: learnLevel,
+      });
+
+      const key = `${row.dex_id}:${row.move_id}:${row.learn_level}`;
+
+      if (!uniqueKeys.has(key)) {
+        rows.push(row);
+        uniqueKeys.add(key);
+      }
+    }
+
+    console.log(`learnsets 준비: ${dexId}/${MAX_DEX_ID}`);
+  }
+
+  return rows;
+}
+
+// learnsets에서 실제 사용하는 move_id만 상세 조회해서 moves 테이블에 저장한다.
+// 사용하지 않는 전체 기술을 무작정 저장하지 않아 seed 시간과 DB 크기를 줄인다.
+async function fetchMoveRows(moveIds: string[]): Promise<MoveRow[]> {
+  const rows: MoveRow[] = [];
+
+  for (const moveId of moveIds) {
+    const move = await fetchMove(moveId);
+
+    rows.push(
+      MoveRow.parse({
+        id: moveId,
+        ko_name: findLocalizedName(move.names, moveId),
+        en_name: move.name,
+        type_id: move.type.name,
+        damage_class: move.damage_class.name,
+        power: move.power ?? 0,
+        accuracy: move.accuracy ?? 0,
+        pp: move.pp ?? 1,
+        effect_text: findEffectText(move.effect_entries),
+        status_effect_chance: move.effect_chance ?? 0,
+      }),
+    );
+  }
+
+  return rows;
 }
 
 async function main() {
-  const rawPokemonMap = await readJsonFile<unknown>('data/pokemon.json');
-  const pokemonMap: PokemonJsonByDexId = parseWithSchema(PokemonJsonByDexIdSchema, rawPokemonMap, 'data/pokemon.json');
-  const pokemons = Object.values(pokemonMap);
+  const dexIds = Array.from({ length: MAX_DEX_ID }, (_, index) => index + 1);
 
-  await upsertTypes(pokemons);
-  await upsertPokemonSpecies(pokemons);
+  const typeRows = await fetchTypes();
+  await upsertChunked('types', typeRows, 'id');
 
-  console.log('pokemon_species seed 테스트 완료');
+  const typeChartRows = await fetchTypeCharts();
+  await upsertChunked('type_charts', typeChartRows, 'attack_type_id,defense_type_id');
+
+  const pokemonSpeciesRows = await fetchPokemonSpeciesRows(dexIds);
+  await upsertChunked('pokemon_species', pokemonSpeciesRows, 'dex_id');
+
+  const learnsetRows = await fetchLearnsetRows(dexIds);
+  const moveIds = [...new Set(learnsetRows.map((row) => row.move_id))];
+
+  const moveRows = await fetchMoveRows(moveIds);
+  await upsertChunked('moves', moveRows, 'id');
+
+  await upsertChunked('learnsets', learnsetRows, 'dex_id,move_id,learn_level');
+
+  console.log('PokeAPI 기반 7세대 game data seed 완료');
 }
 
 main().catch((error) => {

--- a/src/app/(main)/(start)/build-deck/_components/StarterPokemonSelect.tsx
+++ b/src/app/(main)/(start)/build-deck/_components/StarterPokemonSelect.tsx
@@ -3,7 +3,7 @@
 import type { Generation } from '../_types/pokemon';
 import { useMemo, useState, useTransition } from 'react';
 import type { SelectedPokemon } from '@/app/(main)/(start)/_types/trainer';
-import { generationTabs, starterPokemonDexIds } from '@/app/(main)/(start)/build-deck/_constants/starter-pokemon';
+import { generationTabs } from '@/app/(main)/(start)/build-deck/_constants/starter-pokemon';
 import DialogBox from '@/shared/components/DialogBox';
 import GenerationTabs from './GenerationTabs';
 import { motion } from 'framer-motion';
@@ -11,15 +11,15 @@ import StarterPokemonCard from '@/app/(main)/(start)/build-deck/_components/Star
 import type { PokemonData } from '@/shared/types/pokemon';
 import PokemonDetailModal from '@/shared/components/pokemon/PokemonDetailModal';
 import { useRouter } from 'next/navigation';
-import { getPokemonByDexId } from '@/shared/data/pokemon-catalog';
 import { toast } from 'sonner';
 import { selectStarterPokemons } from '@/features/trainer/actions/trainerActions';
 
 type StarterPokemonSelectProps = {
   trainerName: string;
+  starterPokemons: PokemonData[];
 };
 
-export default function StarterPokemonSelect({ trainerName }: StarterPokemonSelectProps) {
+export default function StarterPokemonSelect({ trainerName, starterPokemons }: StarterPokemonSelectProps) {
   const [activeGeneration, setActiveGeneration] = useState<Generation>(1);
   const [detailPokemon, setDetailPokemon] = useState<PokemonData | null>(null);
   const [selectedPokemons, setSelectedPokemons] = useState<SelectedPokemon[]>([]);
@@ -30,11 +30,8 @@ export default function StarterPokemonSelect({ trainerName }: StarterPokemonSele
   const maxSelectedPokemonCount = 3;
 
   const pokemons = useMemo(() => {
-    return starterPokemonDexIds
-      .map((pokemonId) => getPokemonByDexId(pokemonId))
-      .filter((pokemon): pokemon is PokemonData => Boolean(pokemon))
-      .filter((pokemon) => pokemon.generation === activeGeneration);
-  }, [activeGeneration]);
+    return starterPokemons.filter((pokemon) => pokemon.generation === activeGeneration);
+  }, [activeGeneration, starterPokemons]);
 
   const selectedPokemonIds = selectedPokemons.map((pokemon) => pokemon.dexId);
 
@@ -58,7 +55,7 @@ export default function StarterPokemonSelect({ trainerName }: StarterPokemonSele
   };
 
   const handleOpenDetail = async (pokemonId: number) => {
-    setDetailPokemon(getPokemonByDexId(pokemonId) ?? null);
+    setDetailPokemon(starterPokemons.find((pokemon) => pokemon.dexId === pokemonId) ?? null);
   };
 
   const handleCloseDetail = () => {

--- a/src/app/(main)/(start)/build-deck/page.tsx
+++ b/src/app/(main)/(start)/build-deck/page.tsx
@@ -1,6 +1,9 @@
 import StarterPokemonSelect from '@/app/(main)/(start)/build-deck/_components/StarterPokemonSelect';
+import { starterPokemonDexIds } from '@/app/(main)/(start)/build-deck/_constants/starter-pokemon';
+import { getPokemonByDexIds } from '@/entities/pokemon/api/pokemonApi';
 import { getOnboardingPath, getTrainerProfile } from '@/entities/trainer/api/trainerApi';
 import SilhouetteBackground from '@/shared/components/SilhouetteBackground';
+
 import { redirect } from 'next/navigation';
 
 export default async function BuildDeckPage() {
@@ -16,6 +19,8 @@ export default async function BuildDeckPage() {
     redirect('/nickname');
   }
 
+  const starterPokemons = await getPokemonByDexIds([...starterPokemonDexIds]);
+
   return (
     <main className="relative min-h-screen overflow-hidden bg-gradient-to-b from-[#F9F9F9] to-[#E1E1E1]">
       <SilhouetteBackground
@@ -24,7 +29,7 @@ export default async function BuildDeckPage() {
       />
 
       <div className="relative z-10 mx-auto flex min-h-screen w-full max-w-7xl items-center justify-center px-6 py-8">
-        <StarterPokemonSelect trainerName={trainer.nickname} />
+        <StarterPokemonSelect trainerName={trainer.nickname} starterPokemons={starterPokemons} />
       </div>
     </main>
   );

--- a/src/app/(main)/home/page.tsx
+++ b/src/app/(main)/home/page.tsx
@@ -7,7 +7,7 @@ import { getTrainerSummary } from '@/entities/trainer/api/trainerApi';
 import { getPokemonCount } from '@/entities/pokemon/api/pokemonApi';
 
 export default async function HomePage() {
-  const [trainer, totalPokemonCount] = await Promise.all([getTrainerSummary(), getPokemonCount()]);
+  const [trainer, totalPokemonCount] = await Promise.all([getTrainerSummary(), getPokemonCount().catch(() => 0)]);
 
   if (!trainer) {
     redirect('/');

--- a/src/app/(main)/home/page.tsx
+++ b/src/app/(main)/home/page.tsx
@@ -1,19 +1,18 @@
 import HomeActionCards from '@/app/(main)/home/_components/HomeActionCards';
 import HomeBanner from '@/app/(main)/home/_components/HomeBanner';
 import TrainerStatusBar from '@/app/(main)/home/_components/TrainerStatusBar';
-import { pokemonCatalog } from '@/shared/data/pokemon-catalog';
 import HomeHeader from '@/shared/components/HomeHeader';
 import { redirect } from 'next/navigation';
 import { getTrainerSummary } from '@/entities/trainer/api/trainerApi';
+import { getPokemonCount } from '@/entities/pokemon/api/pokemonApi';
 
 export default async function HomePage() {
-  const trainer = await getTrainerSummary();
+  const [trainer, totalPokemonCount] = await Promise.all([getTrainerSummary(), getPokemonCount()]);
 
   if (!trainer) {
     redirect('/');
   }
 
-  const totalPokemonCount = Object.keys(pokemonCatalog).length;
   const battleRecord = trainer.battleRecord ?? { wins: 0, losses: 0 };
 
   return (

--- a/src/app/(main)/pokedex/_components/DexPage.tsx
+++ b/src/app/(main)/pokedex/_components/DexPage.tsx
@@ -2,7 +2,6 @@
 
 import { useState, useMemo, useSyncExternalStore } from 'react';
 
-import { getAllPokemon } from '@/shared/data/pokemon-catalog';
 import type { PokemonData, PokemonType } from '@/shared/types/pokemon';
 import type { TrainerData } from '@/app/(main)/(start)/_types/trainer';
 import { storageKeys } from '@/app/(main)/(start)/_constants/key';
@@ -46,7 +45,11 @@ function parseOwnedPokemonIds(raw: string | null): number[] {
   }
 }
 
-export default function DexPage() {
+type DexPageProps = {
+  pokemons: PokemonData[];
+};
+
+export default function DexPage({ pokemons }: DexPageProps) {
   const [search, setSearch] = useState('');
   const [generations, setGenerations] = useState<string[]>([]);
   const [types, setTypes] = useState<PokemonType[]>([] as PokemonType[]);
@@ -83,8 +86,7 @@ export default function DexPage() {
     setPage(1);
   };
 
-  const data = getAllPokemon();
-  const filteredData = data.filter((pokemon) => {
+  const filteredData = pokemons.filter((pokemon) => {
     //이름 검색
     const matchSearch = search === '' || pokemon.koName.includes(search);
     //세대 검색

--- a/src/app/(main)/pokedex/page.tsx
+++ b/src/app/(main)/pokedex/page.tsx
@@ -1,6 +1,8 @@
 // page.tsx
 import DexPage from './_components/DexPage';
+import { getAllPokemons } from '@/entities/pokemon/api/pokemonApi';
 
-export default function Page() {
-  return <DexPage />;
+export default async function Page() {
+  const pokemons = await getAllPokemons();
+  return <DexPage pokemons={pokemons} />;
 }

--- a/src/app/api/type-weaknesses/route.ts
+++ b/src/app/api/type-weaknesses/route.ts
@@ -26,7 +26,7 @@ export async function GET(request: Request) {
   const supabase = await createClient();
 
   const { data, error } = await supabase
-    .from('type-charts')
+    .from('type_charts')
     .select('attack_type_id, defense_type_id, multiplier')
     .in('defense_type_id', validDefenderTypes);
 
@@ -35,11 +35,12 @@ export async function GET(request: Request) {
   }
 
   const effectivenessByAttackType = new Map<PokemonTypeValue, number>();
+  const rows = data ?? [];
 
-  data.forEach((row) => {
+  for (const row of rows) {
     const parsedAttackType = PokemonType.safeParse(row.attack_type_id);
 
-    if (!parsedAttackType.success) return;
+    if (!parsedAttackType.success) continue;
 
     const attackType = parsedAttackType.data;
     const current = effectivenessByAttackType.get(attackType) ?? 1;
@@ -51,5 +52,5 @@ export async function GET(request: Request) {
       .map(([attackType]) => attackType);
 
     return NextResponse.json({ weaknesses });
-  });
+  }
 }

--- a/src/app/api/type-weaknesses/route.ts
+++ b/src/app/api/type-weaknesses/route.ts
@@ -1,0 +1,55 @@
+// 약점 목록만 계산
+import { NextResponse } from 'next/server';
+import { createClient } from '@/shared/lib/supabase/server';
+import { PokemonType, type PokemonType as PokemonTypeValue } from '@/shared/types';
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const defenderTypes = searchParams
+    .get('types')
+    ?.split(',')
+    .map((type) => type.trim())
+    .filter(Boolean);
+
+  if (!defenderTypes?.length) {
+    return NextResponse.json({ weaknesses: [] });
+  }
+
+  const parsedTypes = defenderTypes.map((type) => PokemonType.safeParse(type));
+
+  if (parsedTypes.some((result) => !result.success)) {
+    return NextResponse.json({ error: 'Invalid pokemon type' }, { status: 400 });
+  }
+
+  const validDefenderTypes = parsedTypes.map((result) => result.data) as PokemonTypeValue[];
+
+  const supabase = await createClient();
+
+  const { data, error } = await supabase
+    .from('type-charts')
+    .select('attack_type_id, defense_type_id, multiplier')
+    .in('defense_type_id', validDefenderTypes);
+
+  if (error) {
+    return NextResponse.json({ error: 'Failed to load type chart' }, { status: 500 });
+  }
+
+  const effectivenessByAttackType = new Map<PokemonTypeValue, number>();
+
+  data.forEach((row) => {
+    const parsedAttackType = PokemonType.safeParse(row.attack_type_id);
+
+    if (!parsedAttackType.success) return;
+
+    const attackType = parsedAttackType.data;
+    const current = effectivenessByAttackType.get(attackType) ?? 1;
+
+    effectivenessByAttackType.set(attackType, current * Number(row.multiplier));
+
+    const weaknesses = [...effectivenessByAttackType.entries()]
+      .filter(([, effectiveness]) => effectiveness > 1)
+      .map(([attackType]) => attackType);
+
+    return NextResponse.json({ weaknesses });
+  });
+}

--- a/src/entities/pokemon/api/pokemonApi.ts
+++ b/src/entities/pokemon/api/pokemonApi.ts
@@ -1,0 +1,111 @@
+import { createClient } from '@/shared/lib/supabase/server';
+import type { PokemonData, PokemonType } from '@/shared/types';
+
+type PokemonSpeciesRow = {
+  dex_id: number;
+  ko_name: string;
+  en_name: string;
+  type1_id: PokemonType;
+  type2_id: PokemonType | null;
+  base_hp: number;
+  base_atk: number;
+  base_def: number;
+  base_spd: number;
+  generation: number;
+  evolution_stage: number;
+  sprite_url: string | null;
+  artwork_url: string | null;
+  height: number;
+  weight: number;
+  category: string;
+  flavor_text: string;
+  ability: { name: string; description: string };
+};
+
+function mapPokemon(row: PokemonSpeciesRow): PokemonData {
+  return {
+    dexId: row.dex_id,
+    koName: row.ko_name,
+    enName: row.en_name,
+    types: [row.type1_id, row.type2_id].filter((type): type is PokemonType => Boolean(type)),
+    baseStats: {
+      hp: row.base_hp,
+      attack: row.base_atk,
+      defense: row.base_def,
+      specialAttack: row.base_atk,
+      specialDefense: row.base_def,
+      speed: row.base_spd,
+    },
+    spriteUrl: row.sprite_url ?? '',
+    artworkUrl: row.artwork_url ?? '',
+    generation: row.generation,
+    evolutionStage: row.evolution_stage,
+    evolvesFromDexId: null,
+    evolvesAtFloor: null,
+    category: row.category,
+    height: Number(row.height),
+    weight: Number(row.weight),
+    flavorText: row.flavor_text,
+    ability: row.ability,
+  };
+}
+
+const pokemonSelect = `
+  dex_id,
+  ko_name,
+  en_name,
+  type1_id,
+  type2_id,
+  base_hp,
+  base_atk,
+  base_def,
+  base_spd,
+  generation,
+  evolution_stage,
+  sprite_url,
+  artwork_url,
+  height,
+  weight,
+  category,
+  flavor_text,
+  ability
+`;
+
+export async function getAllPokemons() {
+  const supabase = await createClient();
+
+  const { data, error } = await supabase
+    .from('pokemon_species')
+    .select(pokemonSelect)
+    .order('dex_id', { ascending: true });
+
+  if (error) throw new Error(`포켓몬 데이터를 불러오지 못했습니다: ${error.message}`);
+
+  return (data as PokemonSpeciesRow[]).map(mapPokemon);
+}
+
+export async function getPokemonByDexIds(dexIds: number[]) {
+  if (dexIds.length === 0) return [];
+
+  const supabase = await createClient();
+
+  const { data, error } = await supabase
+    .from('pokemon_species')
+    .select(pokemonSelect)
+    .in('dex_id', dexIds)
+    .order('dex_id', { ascending: true });
+
+  if (error) throw new Error(`포켓몬 데이터를 불러오지 못했습니다: ${error.message}`);
+
+  return (data as PokemonSpeciesRow[]).map(mapPokemon);
+}
+
+export async function getPokemonCount() {
+  const supabase = await createClient();
+
+  const { count, error } = await supabase.from('pokemon_species').select('*', { count: 'exact', head: true });
+
+  if (error) throw new Error(`포켓몬 수를 불러오지 못했습니다: ${error.message}`);
+
+  return count ?? 0;
+}

--- a/src/entities/pokemon/api/pokemonApi.ts
+++ b/src/entities/pokemon/api/pokemonApi.ts
@@ -10,6 +10,8 @@ type PokemonSpeciesRow = {
   base_hp: number;
   base_atk: number;
   base_def: number;
+  base_sp_atk: number;
+  base_sp_def: number;
   base_spd: number;
   generation: number;
   evolution_stage: number;
@@ -32,8 +34,8 @@ function mapPokemon(row: PokemonSpeciesRow): PokemonData {
       hp: row.base_hp,
       attack: row.base_atk,
       defense: row.base_def,
-      specialAttack: row.base_atk,
-      specialDefense: row.base_def,
+      specialAttack: row.base_sp_atk,
+      specialDefense: row.base_sp_def,
       speed: row.base_spd,
     },
     spriteUrl: row.sprite_url ?? '',
@@ -60,6 +62,8 @@ const pokemonSelect = `
   base_atk,
   base_def,
   base_spd,
+  base_sp_atk,
+  base_sp_def,
   generation,
   evolution_stage,
   sprite_url,

--- a/src/shared/components/pokemon/PokemonDetailModal.tsx
+++ b/src/shared/components/pokemon/PokemonDetailModal.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { typeColorMap, typeIconMap, typeLabelMap } from '@/app/(main)/(start)/build-deck/_constants/pokemon-type';
-import { getTypeEffectiveness, TYPE_CHART } from '../../../../data/type-chart';
+import { useEffect, useState } from 'react';
 import type { PokemonData, PokemonType } from '@/shared/types/pokemon';
 import { X } from 'lucide-react';
 import Image from 'next/image';
@@ -13,12 +13,47 @@ interface PokemonDetailModalProps {
 }
 
 export default function PokemonDetailModal({ pokemon, isOpen, onClose }: PokemonDetailModalProps) {
+  const selectedTypesKey = isOpen && pokemon ? pokemon.types.join(',') : '';
+
+  const [weaknessResult, setWeaknessResult] = useState<{
+    typesKey: string;
+    weaknesses: PokemonType[];
+  } | null>(null);
+
+  useEffect(() => {
+    if (!selectedTypesKey) return;
+
+    const controller = new AbortController();
+
+    async function loadWeaknesses(typesKey: string) {
+      const params = new URLSearchParams({ types: typesKey });
+
+      const response = await fetch(`/api/type-weaknesses?${params.toString()}`, {
+        signal: controller.signal,
+      });
+
+      if (!response.ok) return;
+
+      const data = (await response.json()) as { weaknesses?: PokemonType[] };
+
+      setWeaknessResult({
+        typesKey,
+        weaknesses: data.weaknesses ?? [],
+      });
+    }
+
+    loadWeaknesses(selectedTypesKey).catch(() => {
+      // 모달을 닫거나 포켓몬을 바꾸며 abort된 요청은 무시한다.
+    });
+
+    return () => {
+      controller.abort();
+    };
+  }, [selectedTypesKey]);
+
   if (!isOpen || pokemon === null) return null;
 
-  const weaknesses = (Object.keys(TYPE_CHART) as PokemonType[]).filter((attackType) => {
-    return getTypeEffectiveness(attackType, pokemon.types) > 1;
-  });
-
+  const weaknesses = weaknessResult?.typesKey === selectedTypesKey ? weaknessResult.weaknesses : [];
   const mainType = pokemon.types[0];
 
   return (

--- a/src/shared/components/pokemon/PokemonDetailModal.tsx
+++ b/src/shared/components/pokemon/PokemonDetailModal.tsx
@@ -42,8 +42,9 @@ export default function PokemonDetailModal({ pokemon, isOpen, onClose }: Pokemon
       });
     }
 
-    loadWeaknesses(selectedTypesKey).catch(() => {
-      // 모달을 닫거나 포켓몬을 바꾸며 abort된 요청은 무시한다.
+    loadWeaknesses(selectedTypesKey).catch((error) => {
+      if (error instanceof DOMException && error.name === 'AbortError') return;
+      console.error('Failed to load type weaknesses:', error);
     });
 
     return () => {


### PR DESCRIPTION
# Pull Request

## 🎯 작업 내용

<!-- 무엇을 했는지 한 줄로 요약 -->
로컬 data/*.json 파일에 의존하던 포켓몬 데이터 조회 흐름을 PokeAPI 기반 정적 데이터 조회 구조로 변경했습니다.

## 📌 작업 배경

<!-- 왜 이 작업이 필요했는지 -->
기존에는 data/pokemon.json, data/moves.json, data/pokemon-moves.json 파일을 직접 참조해 포켓몬 목록, 상세 정보, 스타팅 포켓몬 선택 화면을 구성했습니다.

하지만 게임 데이터 관리 기준을 외부 API 기반 정적 데이터 생성/조회 흐름으로 전환하기 위해, 로컬 JSON 파일이 없어도 주요 화면이 동작하도록 구조를 수정했습니다.

## 🔨 구현 내용

<!-- 주요 변경사항을 간략히 나열 -->

#### Added (추가)

- PokeAPI 기반 포켓몬 데이터 조회 로직 추가
- 포켓몬 도메인 관련 API/유틸 구조 추가
- 타입 약점 조회 API route 추가
- PokeAPI 데이터 기반 seed script 수정

#### Changed (변경)

- build-deck 스타팅 포켓몬 선택 화면이 로컬 pokemon.json에 직접 의존하지 않도록 변경
- pokedex 목록/상세 화면의 포켓몬 데이터 주입 흐름 변경
- home 페이지의 포켓몬 데이터 참조 방식 변경
- PokemonDetailModal에서 타입 약점 정보를 API 기반으로 조회하도록 수정
- scripts/seed-game-data.ts를 PokeAPI 기반 데이터 흐름에 맞게 수정

#### Fixed (수정)

- 로컬 data/*.json 파일이 없어도 스타팅 포켓몬 선택 및 도감 화면이 정상 동작하도록 수정
## 📸 결과물

<!-- 스크린샷 또는 동작 화면 -->
- 포켓몬 1~7세대, 기술, 종별 레벨업 기술 정상 삽입
<img width="113" height="73" alt="스크린샷 2026-06-04 오후 7 05 22" src="https://github.com/user-attachments/assets/c47904a0-2af3-43d5-be39-ee9b51572de4" />
<img width="108" height="79" alt="스크린샷 2026-06-04 오후 7 05 41" src="https://github.com/user-attachments/assets/19781439-dfdf-4731-9484-d855697bc241" />
<img width="119" height="80" alt="스크린샷 2026-06-04 오후 7 06 04" src="https://github.com/user-attachments/assets/8792511b-f29d-4588-b9b7-ea42110a586f" />



- 스타팅 포켓몬 & 상세 정보 정상 호출
<img width="1512" height="861" alt="스크린샷 2026-06-04 오후 7 34 24" src="https://github.com/user-attachments/assets/157f64d6-5623-431d-839f-d5b05f4f7769" />
<img width="987" height="572" alt="스크린샷 2026-06-04 오후 7 34 34" src="https://github.com/user-attachments/assets/8ef04a0e-ccd5-45fe-b91e-1d0b438df79e" />


-  모든 선택 이후 db에 정상 삽입 확인
<img width="790" height="37" alt="스크린샷 2026-06-04 오후 7 35 40" src="https://github.com/user-attachments/assets/b75c2797-b65c-49ea-a630-169915db7496" />


- 홈 화면에서 1~7세대 총 보유 포켓몬 갯수 확인
<img width="753" height="231" alt="스크린샷 2026-06-04 오후 7 35 00" src="https://github.com/user-attachments/assets/b0b3426a-2951-4d7f-ab0b-e8ca8744f028" />


## 🧪 테스트

<!-- 어떻게 테스트했는지 -->

- [X] data/pokemon.json, data/moves.json, data/pokemon-moves.json 파일명을 .bak으로 변경한 상태에서 화면 동작 확인
- [X] 스타팅 포켓몬 선택 화면 정상 렌더링 확인
- [X] 스타팅 포켓몬 선택 및 다음 흐름 이동 확인
- [X] 도감 페이지 포켓몬 목록 렌더링 확인
- [X] 포켓몬 상세 모달 표시 확인


## 💬 리뷰 요청사항

<!-- 특히 봐주셨으면 하는 부분 -->

- 해당 로직들과 파일 구조 위치가 적절한지 봐주시면 좋겠습니다

## 🔗 관련 링크

<!-- 이슈, 문서, 디자인 등 -->

- Closes #53


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 외부 API 기반 게임 데이터 시드(타입/상성/스피시즈/기술 등) 자동화 스크립트 추가
  * 포켓몬 타입 상성 계산용 GET API 추가
  * DB 기반 포켓몬 조회 API(전체/목록/카운트) 추가

* **개선 사항**
  * 타입 약점 정보를 원격으로 동적 조회하도록 변경
  * 포켓몬 목록과 관련 페이지의 서버측 데이터 로딩으로 흐름 분리 및 성능 개선
  * 시드 실행 전 유효성·안전 확인 로직 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->