### PR TITLE
Feat/#65/home onboarding guide

### DIFF
--- a/src/app/(main)/home/_constants/homeTourSteps.ts
+++ b/src/app/(main)/home/_constants/homeTourSteps.ts
@@ -1,0 +1,64 @@
+export const HOME_TOUR_STORAGE_KEY = 'podeck.home-tour.v1';
+
+export type HomeTourPlacement = 'top' | 'bottom' | 'left' | 'right';
+
+export const homeTourSteps = [
+  {
+    id: 'mission',
+    targetId: 'home-mission',
+    title: '오늘의 미션',
+    description: '매일 갱신되는 미션을 완료하고 보상을 받을 수 있어요.',
+    placement: 'right',
+  },
+  {
+    id: 'history',
+    targetId: 'home-history',
+    title: '배틀 히스토리',
+    description: '최근 배틀 기록과 승패를 빠르게 확인할 수 있어요.',
+    placement: 'top',
+  },
+  {
+    id: 'trainer',
+    targetId: 'home-trainer-status',
+    title: '트레이너 정보',
+    description: '카드팩, 탑 진행도, 배틀 전적을 확인할 수 있어요.',
+    placement: 'left',
+  },
+  {
+    id: 'recommend',
+    targetId: 'home-ai-recommend',
+    title: '오늘의 추천덱',
+    description: 'AI가 추천하는 덱을 바로 사용해볼 수 있어요.',
+    placement: 'left',
+  },
+  {
+    id: 'actions',
+    targetId: 'home-action-cards',
+    title: '도감 & 배틀',
+    description: '포켓몬 도감을 보거나 배틀을 시작할 수 있어요.',
+    placement: 'top',
+  },
+  {
+    id: 'nav',
+    targetId: 'home-navigation',
+    title: '네비게이션',
+    description: '홈, 새소식, 도감, 배틀 페이지로 이동할 수 있어요.',
+    placement: 'bottom',
+  },
+  {
+    id: 'profile',
+    targetId: 'trainer-profile-menu',
+    title: '프로필 설정',
+    description: '닉네임, 프로필 이미지, 로그아웃을 관리할 수 있어요.',
+    placement: 'bottom',
+  },
+  {
+    id: 'news',
+    targetId: 'home-news',
+    title: '새소식',
+    description: '새로운 소식들을 확인해볼 수 있어요',
+    placement: 'top',
+  },
+] as const;
+
+export type HomeTourStep = (typeof homeTourSteps)[number];

--- a/src/app/(main)/home/page.tsx
+++ b/src/app/(main)/home/page.tsx
@@ -2,6 +2,7 @@ import AiDeckRecommendPanel from '@/features/home/AiDeckRecommendPanel';
 import HomeActionCards from '@/features/home/HomeActionCards';
 import HomeBanner from '@/features/home/HomeBanner';
 import HomeMissionCard from '@/features/home/HomeMissionCard';
+import HomeOnboardingGuide from '@/features/home/HomeOnboardingGuide';
 import TrainerStatusCard from '@/features/home/TrainerStatusCard';
 import HomeNewsSection from '@/features/news/HomeNewsSection';
 import HomeHeader from '@/shared/components/HomeHeader';
@@ -28,32 +29,42 @@ export default async function HomePage() {
             <HomeBanner />
 
             <div className="mt-6 grid grid-cols-[300px_minmax(0,1fr)] items-start gap-6">
-              <HomeMissionCard />
-
-              <div className="h-[280px] rounded-[20px] bg-[var(--color-base-3)] p-5 shadow-[0_10px_30px_rgba(0,0,0,0.06)]">
+              <div data-tour-id="home-mission">
+                <HomeMissionCard />
+              </div>
+              <div
+                data-tour-id="home-history"
+                className="h-[280px] rounded-[20px] bg-[var(--color-base-3)] p-5 shadow-[0_10px_30px_rgba(0,0,0,0.06)]"
+              >
                 배틀 히스토리 영역
               </div>
             </div>
 
-            <div className="mt-[27px]">
+            <div data-tour-id="home-action-cards" className="mt-[28px]">
               <HomeActionCards />
             </div>
 
-            <HomeNewsSection />
+            <div data-tour-id="home-news">
+              <HomeNewsSection />
+            </div>
           </div>
 
           <aside className="flex flex-col gap-6">
-            <TrainerStatusCard
-              trainerName={trainer.nickname}
-              avatarUrl={trainer.avatarUrl}
-              cardPackCount={trainer.cardPackCount}
-              currentFloor={trainer.currentFloor}
-              battleRecord={trainer.battleRecord}
-              ownedPokemonCount={trainer.ownedPokemonCount}
-              totalPokemonCount={totalPokemonCount}
-            />
+            <div data-tour-id="home-trainer-status">
+              <TrainerStatusCard
+                trainerName={trainer.nickname}
+                avatarUrl={trainer.avatarUrl}
+                cardPackCount={trainer.cardPackCount}
+                currentFloor={trainer.currentFloor}
+                battleRecord={trainer.battleRecord}
+                ownedPokemonCount={trainer.ownedPokemonCount}
+                totalPokemonCount={totalPokemonCount}
+              />
+            </div>
 
-            <AiDeckRecommendPanel />
+            <div data-tour-id="home-ai-recommend">
+              <AiDeckRecommendPanel />
+            </div>
 
             <Link
               href="https://ktcloud-techup.com/"
@@ -66,13 +77,15 @@ export default async function HomePage() {
                 src="/images/home/ad/techup-banner.svg"
                 alt="kt cloud TECH UP 배너"
                 width={300}
-                height={140}
+                height={130}
                 className="h-full w-full object-cover transition hover:scale-105"
               />
             </Link>
           </aside>
         </div>
       </div>
+
+      <HomeOnboardingGuide userId={trainer.id} />
 
       <footer className="pb-6 text-center text-sm text-[#888888]">© 2026 Team 로켓단. All rights reserved.</footer>
     </main>

--- a/src/features/deck-recommendation/_components/AiDeckCard.tsx
+++ b/src/features/deck-recommendation/_components/AiDeckCard.tsx
@@ -76,7 +76,7 @@ export default function AiDeckCard({
 
         <div className="flex min-w-0 flex-col gap-1">
           <h3 className="text-base-0 text-base leading-[1.4] font-bold tracking-tight">{title}</h3>
-          <p className="text-base-1 max-w-45 text-sm leading-[1.4] tracking-tight">{description}</p>
+          <p className="text-base-1 max-w-none text-sm leading-[1.4] tracking-tight">{description}</p>
         </div>
       </div>
 

--- a/src/features/home/AiDeckRecommendContent.tsx
+++ b/src/features/home/AiDeckRecommendContent.tsx
@@ -68,7 +68,7 @@ export default function AiDeckRecommendContent({ initialResults }: AiDeckRecomme
   const allFailed = !first.ok && !second.ok;
 
   return (
-    <div className="mt-4 flex flex-col gap-3.75">
+    <div className="mt-4 flex flex-col gap-2.5">
       {first.ok && <AiDeckCard title={first.data.title} description={first.data.description} deck={first.data.deck} />}
       {second.ok && (
         <AiDeckCard title={second.data.title} description={second.data.description} deck={second.data.deck} />

--- a/src/features/home/AiDeckRecommendPanel.tsx
+++ b/src/features/home/AiDeckRecommendPanel.tsx
@@ -13,7 +13,7 @@ async function AiDeckRecommendLoader() {
 
 export default function AiDeckRecommendPanel() {
   return (
-    <HomeSidebarPanel title="오늘의 추천 덱" badge="DECK ASSIST" className="min-h-138.75">
+    <HomeSidebarPanel title="오늘의 추천 덱" badge="DECK ASSIST" className="min-h-[445px]">
       <Suspense fallback={<AiDeckRecommendSkeleton />}>
         <AiDeckRecommendLoader />
       </Suspense>

--- a/src/features/home/HomeOnboardingGuide.tsx
+++ b/src/features/home/HomeOnboardingGuide.tsx
@@ -1,0 +1,256 @@
+'use client';
+
+import {
+  HOME_TOUR_STORAGE_KEY,
+  homeTourSteps,
+  type HomeTourPlacement,
+} from '@/app/(main)/home/_constants/homeTourSteps';
+import { useCallback, useEffect, useState, useSyncExternalStore, type CSSProperties } from 'react';
+
+type Rect = {
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+};
+
+type TooltipPosition = {
+  top: number;
+  left: number;
+};
+
+const PADDING = 10;
+const TOOLTIP_WIDTH = 320;
+const TOOLTIP_HEIGHT = 180;
+const VIEWPORT_MARGIN = 16;
+const TOOLTIP_GAP = 16;
+
+const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), Math.max(min, max));
+
+const isSameRect = (previous: Rect | null, next: Rect) =>
+  previous?.top === next.top &&
+  previous.left === next.left &&
+  previous.width === next.width &&
+  previous.height === next.height;
+
+const isSameTooltipPosition = (previous: CSSProperties | null, next: TooltipPosition) =>
+  previous?.top === next.top && previous.left === next.left;
+
+const subscribeHomeTourStorage = () => () => {};
+
+const getHomeTourServerSnapshot = () => false;
+
+interface HomeOnboardingGuideProps {
+  userId: string;
+}
+
+export default function HomeOnboardingGuide({ userId }: HomeOnboardingGuideProps) {
+  const storageKey = `${HOME_TOUR_STORAGE_KEY}.${userId}`;
+  const getHomeTourSnapshot = useCallback(() => {
+    try {
+      return !window.localStorage.getItem(storageKey);
+    } catch {
+      return true;
+    }
+  }, [storageKey]);
+  const shouldShowTour = useSyncExternalStore(subscribeHomeTourStorage, getHomeTourSnapshot, getHomeTourServerSnapshot);
+  const [isDismissed, setIsDismissed] = useState(false);
+  const [stepIndex, setStepIndex] = useState(0);
+  const [targetRect, setTargetRect] = useState<Rect | null>(null);
+  const [tooltipStyle, setTooltipStyle] = useState<CSSProperties | null>(null);
+
+  const isOpen = shouldShowTour && !isDismissed;
+  const currentStep = homeTourSteps[stepIndex];
+  const isLastStep = stepIndex === homeTourSteps.length - 1;
+
+  const closeTour = useCallback(() => {
+    try {
+      window.localStorage.setItem(storageKey, 'true');
+    } finally {
+      setIsDismissed(true);
+    }
+  }, [storageKey]);
+
+  const moveNext = useCallback(() => {
+    if (isLastStep) {
+      closeTour();
+      return;
+    }
+
+    setStepIndex((current) => current + 1);
+  }, [closeTour, isLastStep]);
+
+  useEffect(() => {
+    if (!isOpen || !currentStep) return;
+
+    let animationFrameId = 0;
+
+    const getTarget = () => document.querySelector<HTMLElement>(`[data-tour-id="${currentStep.targetId}"]`);
+
+    const updateTargetState = () => {
+      const target = getTarget();
+
+      if (!target) {
+        setTargetRect(null);
+        setTooltipStyle(null);
+        return;
+      }
+
+      const rect = target.getBoundingClientRect();
+
+      if (rect.width === 0 || rect.height === 0) {
+        moveNext();
+        return;
+      }
+
+      const nextTargetRect = {
+        top: Math.max(rect.top - PADDING, 0),
+        left: Math.max(rect.left - PADDING, 0),
+        width: rect.width + PADDING * 2,
+        height: rect.height + PADDING * 2,
+      };
+
+      const centeredTop = nextTargetRect.top + nextTargetRect.height / 2 - TOOLTIP_HEIGHT / 2;
+      const centeredLeft = nextTargetRect.left + nextTargetRect.width / 2 - TOOLTIP_WIDTH / 2;
+
+      const maxTop = window.innerHeight - TOOLTIP_HEIGHT - VIEWPORT_MARGIN;
+      const maxLeft = window.innerWidth - TOOLTIP_WIDTH - VIEWPORT_MARGIN;
+      const fallbackTop = nextTargetRect.top + nextTargetRect.height + TOOLTIP_GAP;
+
+      const placementStyle: Record<HomeTourPlacement, CSSProperties> = {
+        top: {
+          top: nextTargetRect.top - TOOLTIP_HEIGHT - TOOLTIP_GAP,
+          left: centeredLeft,
+        },
+        bottom: {
+          top: fallbackTop,
+          left: centeredLeft,
+        },
+        left: {
+          top: centeredTop,
+          left: nextTargetRect.left - TOOLTIP_WIDTH - TOOLTIP_GAP,
+        },
+        right: {
+          top: centeredTop,
+          left: nextTargetRect.left + nextTargetRect.width + TOOLTIP_GAP,
+        },
+      };
+
+      const nextTooltipStyle = placementStyle[currentStep.placement];
+      const nextTooltipPosition = {
+        top: clamp(Number(nextTooltipStyle.top), VIEWPORT_MARGIN, maxTop),
+        left: clamp(Number(nextTooltipStyle.left), VIEWPORT_MARGIN, maxLeft),
+      };
+
+      setTargetRect((previous) => (isSameRect(previous, nextTargetRect) ? previous : nextTargetRect));
+      setTooltipStyle((previous) =>
+        isSameTooltipPosition(previous, nextTooltipPosition) ? previous : nextTooltipPosition,
+      );
+    };
+
+    const scheduleUpdate = () => {
+      cancelAnimationFrame(animationFrameId);
+      animationFrameId = requestAnimationFrame(updateTargetState);
+    };
+
+    const target = getTarget();
+
+    target?.scrollIntoView({
+      behavior: 'smooth',
+      block: 'center',
+      inline: 'nearest',
+    });
+
+    scheduleUpdate();
+
+    window.addEventListener('resize', scheduleUpdate);
+    window.addEventListener('scroll', scheduleUpdate, true);
+
+    return () => {
+      cancelAnimationFrame(animationFrameId);
+      window.removeEventListener('resize', scheduleUpdate);
+      window.removeEventListener('scroll', scheduleUpdate, true);
+    };
+  }, [currentStep, isOpen, moveNext]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const closeOnEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        closeTour();
+      }
+    };
+
+    window.addEventListener('keydown', closeOnEscape);
+
+    return () => {
+      window.removeEventListener('keydown', closeOnEscape);
+    };
+  }, [closeTour, isOpen]);
+
+  if (!isOpen || !currentStep || !targetRect || !tooltipStyle) return null;
+
+  return (
+    <div className="fixed inset-0 z-[9999]" role="dialog" aria-modal="true" aria-labelledby="home-tour-title">
+      <div className="absolute right-0 left-0 bg-[var(--color-base-0)]/45" style={{ top: 0, height: targetRect.top }} />
+      <div
+        className="absolute left-0 bg-[var(--color-base-0)]/45"
+        style={{
+          top: targetRect.top,
+          width: targetRect.left,
+          height: targetRect.height,
+        }}
+      />
+      <div
+        className="absolute right-0 bg-[var(--color-base-0)]/45"
+        style={{
+          top: targetRect.top,
+          left: targetRect.left + targetRect.width,
+          height: targetRect.height,
+        }}
+      />
+      <div
+        className="absolute right-0 left-0 bg-[var(--color-base-0)]/45"
+        style={{ top: targetRect.top + targetRect.height, bottom: 0 }}
+      />
+
+      <div
+        className="absolute shadow-[0_0_0_1px_rgba(255,178,26,0.6)] ring-4 ring-[var(--color-base-3)]"
+        style={targetRect}
+      />
+
+      <div
+        className="pointer-events-auto absolute w-[320px] rounded-[16px] bg-[var(--color-base-3)] p-5 shadow-[0_20px_60px_rgba(0,0,0,0.22)]"
+        style={tooltipStyle}
+      >
+        <p className="text-xs font-extrabold text-[var(--color-primary)]">
+          {stepIndex + 1} / {homeTourSteps.length}
+        </p>
+        <h2 id="home-tour-title" className="mt-2 text-xl font-extrabold text-[var(--color-base-0)]">
+          {currentStep.title}
+        </h2>
+        <p className="mt-2 text-[12px] leading-relaxed font-medium text-[var(--color-base-1)]">
+          {currentStep.description}
+        </p>
+
+        <div className="mt-5 flex gap-2">
+          <button
+            type="button"
+            onClick={closeTour}
+            className="h-10 flex-1 cursor-pointer rounded-[10px] border border-[#E5E5E5] text-sm font-extrabold text-[var(--color-base-1)]"
+          >
+            건너뛰기
+          </button>
+          <button
+            type="button"
+            onClick={moveNext}
+            className="h-10 flex-1 cursor-pointer rounded-[10px] bg-[var(--color-primary)] text-sm font-extrabold text-[var(--color-base-3)]"
+          >
+            {isLastStep ? '시작하기' : '다음'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/home/HomeOnboardingGuide.tsx
+++ b/src/features/home/HomeOnboardingGuide.tsx
@@ -91,8 +91,7 @@ export default function HomeOnboardingGuide({ userId }: HomeOnboardingGuideProps
       const target = getTarget();
 
       if (!target) {
-        setTargetRect(null);
-        setTooltipStyle(null);
+        moveNext();
         return;
       }
 

--- a/src/features/trainer/_components/TrainerProfileMenu.tsx
+++ b/src/features/trainer/_components/TrainerProfileMenu.tsx
@@ -106,7 +106,7 @@ export default function TrainerProfileMenu({ nickname, avatarUrl }: TrainerProfi
   };
 
   return (
-    <div className="relative">
+    <div data-tour-id="trainer-profile-menu" className="relative">
       <button
         type="button"
         onClick={() => setIsOpen((current) => !current)}

--- a/src/shared/components/HomeHeader.tsx
+++ b/src/shared/components/HomeHeader.tsx
@@ -31,7 +31,10 @@ export default function HomeHeader({ nickname, avatarUrl }: HomeHeaderProps) {
         </Link>
 
         <div className="flex items-center gap-2 md:gap-4">
-          <nav className="absolute left-1/2 hidden -translate-x-1/2 items-center gap-4 md:flex">
+          <nav
+            data-tour-id="home-navigation"
+            className="absolute left-1/2 hidden -translate-x-1/2 items-center gap-4 md:flex"
+          >
             {homeNavItems.map((item) => {
               const isActive = pathName === item.href || pathName.startsWith(`${item.href}/`);
               const isBattle = item.id === 'battle';


### PR DESCRIPTION
# Pull Request

## 🎯 작업 내용

<!-- 무엇을 했는지 한 줄로 요약 -->
홈 화면 최초 진입 사용자를 위한 사용자 매뉴얼 온보딩 가이드를 추가했습니다

## 📌 작업 배경

<!-- 왜 이 작업이 필요했는지 -->
홈 화면에 미션, 배틀 히스토리, 트레이너 정보, 추천 덱, 액션 카드 등 여러 기능 영역이 추가되면서 신규 사용자가 각 영역의 역할을 빠르게 이해할 수 있도록 안내 흐름이 필요했습니다.

## 🔨 구현 내용

<!-- 주요 변경사항을 간략히 나열 -->

#### Added (추가)

- 홈 사용자 매뉴얼 단계 데이터 추가
- 홈 온보딩 가이드 컴포넌트 추가
- localStorage 기반 사용자별 최초 1회 노출 처리 추가

#### Changed (변경)

- 홈 주요 영역에 온보딩 타겟 `data-tour-id` 연결
- 홈 헤더 네비게이션과 트레이너 프로필 메뉴에 안내 타겟 연결
- 숨겨진 타겟이나 크기가 없는 타겟은 다음 단계로 넘어가도록 방어 처리
- scroll/resize 시 같은 위치 업데이트로 인한 불필요한 재렌더 방지

#### Fixed (수정)

- 온보딩 타겟 미탐색 시 화면이 멈출 수 있는 케이스 방어
- 추천 덱 카드 텍스트 및 홈 영역 정렬 일부 조정

## 📸 결과물

<!-- 스크린샷 또는 동작 화면 -->
- 실행 화면
<img width="1498" height="863" alt="스크린샷 2026-06-15 오후 4 38 19" src="https://github.com/user-attachments/assets/fc5c047e-255d-4415-9cc1-1d15c50bacad" />
<img width="1495" height="862" alt="스크린샷 2026-06-15 오후 4 38 37" src="https://github.com/user-attachments/assets/b608fa2e-54a3-46bf-8441-9bc388b2e510" />
<img width="1496" height="862" alt="image" src="https://github.com/user-attachments/assets/c27ff94a-bc5c-4092-a986-45745d011fe1" />


## 🧪 테스트

<!-- 어떻게 테스트했는지 -->

- [X] 로컬 테스트 완료
- [X] 주요 시나리오 검증
검증한 명령어:

```bash
pnpm lint
pnpm typecheck
pnpm run format:check
pnpm test 
```

## 💬 리뷰 요청사항

<!-- 특히 봐주셨으면 하는 부분 -->

-

## 🔗 관련 링크

<!-- 이슈, 문서, 디자인 등 -->

- Closes #65
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 홈 화면 온보딩 투어 가이드 기능 추가로 사용자가 주요 기능을 단계별로 학습할 수 있습니다.

* **Improvements**
  * 추천 콘텐츠 카드 간 간격 최적화
  * AI 덱 카드 설명 레이아웃 개선으로 더 나은 가독성 제공
  * 패널 크기 및 여백 조정

<!-- end of auto-generated comment: release notes by coderabbit.ai -->