### PR TITLE
Fix: 비인증 사용자 보호 라우트 접근 차단 (#66)

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -21,7 +21,7 @@ export async function middleware(request: NextRequest) {
 
   const isPublic = isPublicPath(pathname);
 
-  if (!user && isPublic) {
+  if (!user && !isPublic) {
     const url = request.nextUrl.clone();
     url.pathname = '/';
     url.search = '';

--- a/middleware.ts
+++ b/middleware.ts
@@ -3,21 +3,28 @@ import { NextResponse, type NextRequest } from 'next/server';
 import { updateSession } from '@/shared/lib/supabase/middleware';
 import { getOnboardingPathForUser } from '@/entities/trainer/api/onboarding';
 
-const protectedPaths = ['/home', '/pokedex', '/mydeck', '/battle', '/build-deck', '/loading', '/nickname'];
+const publicPaths = ['/'];
+const publicPrefixes = ['/auth'];
+const publicApiPrefixes = ['/api/health', '/api/data', '/api/type-weaknesses'];
 
-function isPathMatched(pathname: string, paths: string[]) {
-  return paths.some((path) => pathname === path || pathname.startsWith(`${path}/`));
+function isPublicPath(pathname: string) {
+  return (
+    publicPaths.includes(pathname) ||
+    publicPrefixes.some((path) => pathname.startsWith(path)) ||
+    publicApiPrefixes.some((path) => pathname.startsWith(path))
+  );
 }
 
 export async function middleware(request: NextRequest) {
   const { response, user, supabase } = await updateSession(request);
   const { pathname } = request.nextUrl;
 
-  const isProtectedPath = isPathMatched(pathname, protectedPaths);
+  const isPublic = isPublicPath(pathname);
 
-  if (!user && isProtectedPath) {
+  if (!user && isPublic) {
     const url = request.nextUrl.clone();
     url.pathname = '/';
+    url.search = '';
     return NextResponse.redirect(url);
   }
 
@@ -25,6 +32,7 @@ export async function middleware(request: NextRequest) {
     const nextPath = await getOnboardingPathForUser(supabase, user.id);
     const url = request.nextUrl.clone();
     url.pathname = nextPath;
+    url.search = '';
     return NextResponse.redirect(url);
   }
 


### PR DESCRIPTION
# Pull Request

## 🎯 작업 내용

<!-- 무엇을 했는지 한 줄로 요약 -->
비인증 사용자가 보호 페이지에 직접 접근할 수 있던 문제를 수정했습니다

## 📌 작업 배경

<!-- 왜 이 작업이 필요했는지 -->
기존에는 보호 라우트를 개별 경로 목록으로 관리하고 있어 `/news`처럼 새로 추가된 페이지가 누락되면 비로그인 상태에서도 접근 가능한 문제가 있었습니다.

로그인 전에는 `/` 페이지와 인증 콜백 등 최소 공개 경로만 접근 가능해야 하므로, 라우트 보호 기준을 정리했습니다.


## 🔨 구현 내용

<!-- 주요 변경사항을 간략히 나열 -->

#### Added (추가)

-

#### Changed (변경)

- 보호 라우트 관리 방식을 `protectedPaths` 목록 방식에서 `publicPaths` / `publicPrefixes` 허용 방식으로 변경
- 비인증 사용자는 공개 경로 외 모든 페이지 접근 시 `/`로 리다이렉트
- 인증 사용자가 `/`에 접근하면 온보딩 상태에 맞는 다음 경로로 리다이렉트

#### Fixed (수정)

- 비로그인 상태에서 `/news`, `/build-deck` 등 보호되어야 하는 페이지에 직접 접근 가능하던 문제 수정
- 새 페이지 추가 시 보호 라우트 목록 누락으로 인증 우회가 발생할 수 있는 구조 개선


## 📸 결과물

<!-- 스크린샷 또는 동작 화면 -->

## 🧪 테스트

<!-- 어떻게 테스트했는지 -->

- [x] 로컬 테스트 완료
- [x] 주요 시나리오 검증


검증 시나리오:

- 비로그인 상태에서 `/` 접근 가능
- 비로그인 상태에서 `/home`, `/news`, `/build-deck` 접근 시 `/`로 리다이렉트
- 로그인 상태에서 `/` 접근 시 온보딩 상태에 맞는 경로로 리다이렉트

## 💬 리뷰 요청사항

<!-- 특히 봐주셨으면 하는 부분 -->

- 공개 경로로 유지해야 하는 `/auth`, `/api` 범위가 적절한지 확인 부탁드립니다.
- 인증 사용자 `/` 접근 시 온보딩 경로 분기 흐름이 의도와 맞는지 확인 부탁드립니다.

## 🔗 관련 링크

<!-- 이슈, 문서, 디자인 등 -->

- Closes #66

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Refactor
* 페이지 접근 제어 로직을 개선하여 더 효율적인 경로 관리가 가능해졌습니다.
* 인증 상태에 따른 리다이렉트 동작을 최적화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->