### PR TITLE
Feat: 배틀 결과를 일일 미션 진행도에 반영 (#71)

### DIFF
--- a/src/features/battle/actions/battleResultActions.ts
+++ b/src/features/battle/actions/battleResultActions.ts
@@ -1,0 +1,41 @@
+// 특정 타입 미션 및 3승 미션 작동을 위한 배틀 결과 저장
+
+'use server';
+
+import { createClient } from '@/shared/lib/supabase/server';
+
+type SaveBattleResultInput = {
+  floor: number;
+  won: boolean;
+  turnCount: number;
+  playerDeckDexIds: number[];
+  playerDeckTypeIds: string[];
+};
+
+export async function saveBattleResult(input: SaveBattleResultInput) {
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return { ok: false, message: '로그인이 필요합니다.' };
+  }
+
+  const { error } = await supabase.from('battle_histories').insert({
+    user_id: user.id,
+    floor: input.floor,
+    won: input.won,
+    turn_count: input.turnCount,
+    player_deck_dex_ids: input.playerDeckDexIds,
+    player_deck_type_ids: [...new Set(input.playerDeckTypeIds)],
+    fought_at: new Date().toISOString(),
+  });
+
+  if (error) {
+    return { ok: false, message: '배틀 결과 저장에 실패했습니다.' };
+  }
+
+  return { ok: true };
+}


### PR DESCRIPTION
# Pull Request

## 🎯 작업 내용

<!-- 무엇을 했는지 한 줄로 요약 -->
배틀 결과 저장 시 일일 미션 조건 판정에 필요한 데이터를 함께 기록하도록 연동했습니다.

## 📌 작업 배경

<!-- 왜 이 작업이 필요했는지 -->
오늘의 미션 중 “배틀 3회 승리”, “특정 타입 포함 덱으로 승리” 미션은 실제 배틀 결과와 사용 덱 타입 정보를 기반으로 진행도를 계산해야 합니다.

## 🔨 구현 내용

<!-- 주요 변경사항을 간략히 나열 -->

#### Added (추가)

- 배틀 결과 저장 액션 추가
- 승리 여부와 사용 덱 타입 정보를 미션 진행도 판정에 활용할 수 있도록 기록


#### Changed (변경)

- 배틀 종료 후 `battle_histories`에 일일 미션 조회에 필요한 결과 데이터를 저장하도록 변경

#### Fixed (수정)

- 특정 타입 포함 덱 승리 미션을 판정할 수 있도록 `player_deck_type_ids` 기반 데이터 흐름 정리

## 📸 결과물

<!-- 스크린샷 또는 동작 화면 -->

## 🧪 테스트

<!-- 어떻게 테스트했는지 -->

- [x] 로컬 테스트 완료
- [x] 주요 시나리오 검증

## 💬 리뷰 요청사항

<!-- 특히 봐주셨으면 하는 부분 -->

-

## 🔗 관련 링크

<!-- 이슈, 문서, 디자인 등 -->

- Closes #71
