### PR TITLE
Feat] 무한의 탑 AI 덱 추천 챗봇 구현 (#62)

### DIFF
--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -1,0 +1,9 @@
+# EC2 호스트의 deploy/.env 로 복사해서 채운다 (실제 .env 는 커밋 금지)
+
+# Caddy 자동 HTTPS에 사용할 도메인. 이 EC2의 Elastic IP를 A 레코드로 가리켜야 한다.
+# 도메인이 없으면 DuckDNS 같은 무료 서브도메인을 사용한다.
+DOMAIN=llm.example.com
+
+# Ollama 접근용 비밀 토큰. 길고 무작위로 생성한다: openssl rand -hex 32
+# 동일한 값을 Vercel 환경변수 LLM_API_KEY 에도 넣는다.
+LLM_API_KEY=replace_with_openssl_rand_hex_32

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -1,0 +1,10 @@
+# Caddy: 자동 HTTPS + Bearer 토큰 인증 후 Ollama로 리버스 프록시
+# Vercel 서버에서 Authorization: Bearer <LLM_API_KEY> 헤더를 보내야만 통과한다.
+
+{$DOMAIN} {
+	# Authorization 헤더가 정확히 "Bearer <LLM_API_KEY>"가 아니면 차단
+	@unauthorized not header Authorization "Bearer {$LLM_API_KEY}"
+	respond @unauthorized "Unauthorized" 401
+
+	reverse_proxy ollama:11434
+}

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,67 @@
+# LLM 서버 배포 (EC2 GPU + Docker Compose)
+
+옵션 2 구성: **Next.js는 Vercel**, **이 EC2는 Ollama 전용 LLM 서버**.
+Vercel 서버 액션이 HTTPS + Bearer 토큰으로 EC2의 Caddy를 호출하고, Caddy가 토큰 검증 후 내부 Ollama로 프록시한다.
+
+```
+사용자 → Vercel(Next.js) → https://<DOMAIN> (Caddy: 토큰 검증) → ollama:11434 (내부망)
+```
+
+이 디렉터리는 **기성품 이미지(ollama/ollama, caddy:2)만 조합**하므로 Dockerfile/.dockerignore가 없다.
+Next.js 앱은 Vercel이 빌드/배포한다.
+
+## 1. EC2 준비
+
+- 인스턴스: **g4dn.xlarge**(T4 16GB) 권장 — 7.8B 모델 기준 최소 GPU
+- AMI: Deep Learning AMI(NVIDIA 드라이버 포함) 또는 Ubuntu + 드라이버/`nvidia-container-toolkit` 수동 설치
+- **Elastic IP 할당** (stop/start 시 IP 고정)
+- 보안 그룹 인바운드: **80, 443만** 개방. **11434는 절대 열지 않는다.**
+- 도메인 A 레코드 → Elastic IP (무료 도메인: DuckDNS)
+
+GPU 인식 확인:
+
+```bash
+docker run --rm --gpus all ollama/ollama nvidia-smi
+```
+
+## 2. 설정
+
+```bash
+cd deploy
+cp .env.example .env
+# .env 편집: DOMAIN, LLM_API_KEY (openssl rand -hex 32 로 생성)
+```
+
+## 3. 기동 + 모델 다운로드
+
+```bash
+docker compose up -d
+docker compose exec ollama ollama pull exaone3.5:7.8b
+# 동작 확인 (토큰 필요)
+curl -H "Authorization: Bearer <LLM_API_KEY>" https://<DOMAIN>/api/tags
+```
+
+## 4. Vercel 환경변수
+
+| 키               | 값                           |
+| ---------------- | ---------------------------- |
+| `LLM_BASE_URL`   | `https://<DOMAIN>/api`       |
+| `LLM_API_KEY`    | EC2 `.env`와 **동일한** 토큰 |
+| `LLM_CHAT_MODEL` | `exaone3.5:7.8b`             |
+| `LLM_DECK_MODEL` | `exaone3.5:7.8b`             |
+
+> 앱 코드는 `LLM_API_KEY`가 있으면 `Authorization: Bearer` 헤더를 자동 전송한다.
+> 로컬 개발은 `LLM_API_KEY` 미설정 → 헤더 없이 `http://localhost:11434` 그대로 사용.
+
+## 5. 비용 관리 (데모/포트폴리오 필수)
+
+GPU EC2는 상시 가동 시 비싸다(g4dn.xlarge ≈ 월 $380). **쓸 때만 켠다.**
+
+```bash
+# 데모 전
+aws ec2 start-instances --instance-ids <ID>      # ~30초 후 모델 상주 복귀
+# 데모 후
+aws ec2 stop-instances --instance-ids <ID>       # GPU 과금 중단 (EBS 저장료만)
+```
+
+모델은 `ollama` 볼륨(EBS)에 남으므로 재다운로드 불필요. Elastic IP라 재시작해도 주소 동일.

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,0 +1,52 @@
+# EC2 (GPU) 전용 — Ollama + Caddy 인증 프록시
+# 옵션 2 구성: Next.js는 Vercel, 이 호스트는 LLM 서버만 담당한다.
+# Ollama 11434는 외부에 직접 노출하지 않고, Caddy(443)가 Bearer 토큰을 검증한 뒤에만 프록시한다.
+#
+# 사전 준비(EC2):
+#   - NVIDIA 드라이버 + nvidia-container-toolkit 설치 (Deep Learning AMI면 대부분 포함)
+#   - deploy/.env 파일에 DOMAIN, LLM_API_KEY 설정 (deploy/.env.example 참고)
+#   - DOMAIN의 A 레코드가 이 EC2의 Elastic IP를 가리켜야 Caddy 자동 HTTPS가 동작
+#
+# 기동:  docker compose up -d
+# 모델:  docker compose exec ollama ollama pull exaone3.5:7.8b
+
+services:
+  ollama:
+    image: ollama/ollama:latest
+    container_name: ollama
+    restart: unless-stopped
+    expose:
+      - '11434' # 컨테이너 네트워크 내부에만 노출 (호스트 포트 매핑 X)
+    environment:
+      OLLAMA_KEEP_ALIVE: '-1' # 모델을 메모리에 상주시켜 cold start 방지
+    volumes:
+      - ollama:/root/.ollama
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+
+  caddy:
+    image: caddy:2
+    container_name: caddy
+    restart: unless-stopped
+    ports:
+      - '80:80'
+      - '443:443'
+    environment:
+      DOMAIN: ${DOMAIN}
+      LLM_API_KEY: ${LLM_API_KEY}
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+    depends_on:
+      - ollama
+
+volumes:
+  ollama:
+  caddy_data:
+  caddy_config:

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -5,6 +5,7 @@ import { createClient } from '@/shared/lib/supabase/server';
 
 const LLM_BASE_URL = process.env.LLM_BASE_URL ?? 'http://localhost:11434/api';
 const LLM_DECK_MODEL = process.env.LLM_DECK_MODEL ?? 'qwen2.5:7b';
+const LLM_API_KEY = process.env.LLM_API_KEY;
 
 const RequestSchema = z.object({
   floorNumber: z.number().min(1).max(999),
@@ -54,7 +55,10 @@ export async function POST(req: Request) {
 
     const ollamaResponse = await fetch(`${LLM_BASE_URL}/chat`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        ...(LLM_API_KEY ? { Authorization: `Bearer ${LLM_API_KEY}` } : {}),
+      },
       body: JSON.stringify({
         model: LLM_DECK_MODEL,
         messages: [

--- a/src/features/chat/ChatbotModal.tsx
+++ b/src/features/chat/ChatbotModal.tsx
@@ -21,6 +21,19 @@ import type { ChatDeckSlot, ChatMessage } from '@/shared/stores/overlay-store';
 
 const TYPE_OPTIONS = PokemonType.options.map((type) => ({ type, label: typeLabelMap[type] ?? type }));
 
+// 자유 입력에서 대상 층을 추출한다. 명시적 "N층"이 우선, 없으면 다음/이전 같은 상대 표현을 해석한다
+function parseRequestedFloor(text: string, currentFloor: number): number | null {
+  const numbered = [...text.matchAll(/(\d+)\s*층/g)].at(-1)?.[1];
+  if (numbered) return Number(numbered);
+
+  if (/다다음\s*층/.test(text)) return currentFloor + 2;
+  if (/다음\s*층/.test(text)) return currentFloor + 1;
+  if (/(이전|전)\s*층/.test(text)) return Math.max(1, currentFloor - 1);
+  if (/(이번|현재|지금|이)\s*층/.test(text)) return currentFloor;
+
+  return null;
+}
+
 export default function ChatbotModal() {
   const { chatMessages } = useOverlayStore((state) => state);
   const currentFloor = useOverlayStore((state) => state.currentFloor ?? 1);
@@ -88,6 +101,20 @@ export default function ChatbotModal() {
     e.preventDefault();
     if (!input.trim() || busy) return;
 
+    const requestedFloor = parseRequestedFloor(input, currentFloor);
+    // 현재 층 +1층까지만 안내 가능
+    if (requestedFloor !== null && requestedFloor > currentFloor + 1) {
+      setChatMessages((prev) => [
+        ...prev,
+        { role: 'user', content: input },
+        { role: 'assistant', content: `현재 ${currentFloor}층에서는 ${requestedFloor}층 공략을 도와드릴 수 없어요.` },
+      ]);
+      setInput('');
+      return;
+    }
+
+    const targetFloor = requestedFloor && requestedFloor >= 1 ? requestedFloor : currentFloor;
+
     const userMessage: ChatMessage = { role: 'user', content: input };
     const updatedMessages = [...chatMessages, userMessage];
 
@@ -98,7 +125,7 @@ export default function ChatbotModal() {
     setChatMessages((prev) => [...prev, { role: 'assistant', content: '' }]);
 
     try {
-      const textStream = await streamChatResponse(updatedMessages, currentFloor);
+      const textStream = await streamChatResponse(updatedMessages, targetFloor);
 
       for await (const textDelta of textStream) {
         updateLastAssistantMessage(textDelta);
@@ -131,7 +158,7 @@ export default function ChatbotModal() {
         <button
           type="button"
           onClick={closeChat}
-          className="text-base-1 hover:text-secondary-1 text-xs font-semibold transition-colors"
+          className="text-base-1 hover:text-secondary-1 cursor-pointer text-xs font-semibold transition-colors"
         >
           접기
         </button>
@@ -253,7 +280,7 @@ export default function ChatbotModal() {
         <button
           type="submit"
           disabled={!input.trim() || busy}
-          className="bg-primary text-base-3 h-10 w-11 shrink-0 rounded-xl text-sm font-bold disabled:cursor-not-allowed disabled:opacity-50"
+          className="bg-primary text-base-3 h-10 w-11 shrink-0 cursor-pointer rounded-xl text-sm font-bold disabled:cursor-not-allowed disabled:opacity-50"
         >
           전송
         </button>

--- a/src/features/chat/ChatbotModal.tsx
+++ b/src/features/chat/ChatbotModal.tsx
@@ -1,12 +1,25 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState, useTransition } from 'react';
 
-import { streamChatResponse } from '@/features/chat/actions';
+import { typeLabelMap } from '@/app/(main)/(start)/build-deck/_constants/pokemon-type';
+import {
+  analyzeEntryDeck,
+  copyCounterDeckToUser,
+  loadEntryDeck,
+  recommendCounterDeck,
+  recommendTypeDeck,
+  streamChatResponse,
+} from '@/features/chat/actions';
+import type { DeckSuggestion } from '@/features/chat/actions';
+import AiDeckCard from '@/features/deck-recommendation/_components/AiDeckCard';
 import { cn } from '@/shared/lib/cn';
 import { useOverlayStore } from '@/shared/stores/overlay-store';
+import { PokemonType } from '@/shared/types/pokemon';
 
-import type { ChatMessage } from '@/shared/stores/overlay-store';
+import type { ChatDeckSlot, ChatMessage } from '@/shared/stores/overlay-store';
+
+const TYPE_OPTIONS = PokemonType.options.map((type) => ({ type, label: typeLabelMap[type] ?? type }));
 
 export default function ChatbotModal() {
   const { chatMessages } = useOverlayStore((state) => state);
@@ -15,16 +28,65 @@ export default function ChatbotModal() {
 
   const [input, setInput] = useState('');
   const [isTyping, setIsTyping] = useState(false);
+  const [isPending, startTransition] = useTransition();
+  const [deckLoading, setDeckLoading] = useState(true);
+  const [entryReady, setEntryReady] = useState(false);
+  const [entryHint, setEntryHint] = useState('');
+  const [pickerOpen, setPickerOpen] = useState(false);
 
   const scrollRef = useRef<HTMLDivElement>(null);
+
+  // 챗봇이 열리면 등록 덱(pokedex_entries)을 미리 읽어 분석 칩 활성화 여부를 결정한다
+  useEffect(() => {
+    let active = true;
+    loadEntryDeck().then((res) => {
+      if (!active) return;
+      setEntryReady(res.ok);
+      if (!res.ok) setEntryHint(res.message);
+      setDeckLoading(false);
+    });
+    return () => {
+      active = false;
+    };
+  }, []);
 
   useEffect(() => {
     scrollRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [chatMessages]);
 
+  const busy = isPending || isTyping;
+
+  function runSuggestion(userLabel: string, title: string, action: () => Promise<DeckSuggestion>) {
+    if (busy) return;
+    setPickerOpen(false);
+    setChatMessages((prev) => [...prev, { role: 'user', content: userLabel }]);
+    startTransition(async () => {
+      const res = await action();
+      setChatMessages((prev) =>
+        res.ok
+          ? [...prev, { role: 'assistant', content: res.explanation, title, deck: res.deck }]
+          : [...prev, { role: 'assistant', content: res.message }],
+      );
+    });
+  }
+
+  function handleUseDeck(deck: ChatDeckSlot[]) {
+    if (busy) return;
+    startTransition(async () => {
+      const res = await copyCounterDeckToUser(deck.map((d) => d.dexId));
+      setChatMessages((prev) => [
+        ...prev,
+        {
+          role: 'assistant',
+          content: res.success ? (res.message ?? '덱이 저장되었습니다.') : (res.error ?? '덱 저장에 실패했습니다.'),
+        },
+      ]);
+    });
+  }
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!input.trim() || isTyping) return;
+    if (!input.trim() || busy) return;
 
     const userMessage: ChatMessage = { role: 'user', content: input };
     const updatedMessages = [...chatMessages, userMessage];
@@ -79,46 +141,147 @@ export default function ChatbotModal() {
       <div className="bg-base-2/50 flex-1 space-y-4 overflow-y-auto p-4">
         {chatMessages.map((message, index) => (
           <div key={index} className={cn('flex', message.role === 'user' ? 'justify-end' : 'justify-start')}>
-            <div
-              className={cn(
-                'max-w-[80%] rounded-2xl px-4 py-2.5 text-sm leading-relaxed whitespace-pre-line shadow-sm',
-                message.role === 'user'
-                  ? 'bg-primary text-base-3 rounded-tr-none'
-                  : 'border-base-2 bg-base-3 text-base-0 rounded-tl-none border',
-              )}
-            >
-              {message.content.replace(/\*\*/g, '') || (
-                // 로딩 애니메이션
-                <div className="flex items-center justify-center gap-1 py-1">
-                  <span className="bg-base-1 h-1.5 w-1.5 animate-bounce rounded-full [animation-delay:0ms]" />
-                  <span className="bg-base-1 h-1.5 w-1.5 animate-bounce rounded-full [animation-delay:150ms]" />
-                  <span className="bg-base-1 h-1.5 w-1.5 animate-bounce rounded-full [animation-delay:300ms]" />
-                </div>
-              )}
-            </div>
+            {message.deck ? (
+              <div className="flex w-full flex-col gap-2">
+                <AiDeckCard
+                  badge="추천"
+                  title={message.title ?? '추천 덱'}
+                  description=""
+                  deck={message.deck}
+                  onUseDeck={() => handleUseDeck(message.deck ?? [])}
+                  disabled={busy}
+                />
+                {message.content && (
+                  <p className="text-base-0 px-1 text-sm leading-relaxed whitespace-pre-line">
+                    {message.content.replace(/\*\*/g, '')}
+                  </p>
+                )}
+              </div>
+            ) : (
+              <div
+                className={cn(
+                  'max-w-[80%] rounded-2xl px-4 py-2.5 text-sm leading-relaxed whitespace-pre-line shadow-sm',
+                  message.role === 'user'
+                    ? 'bg-primary text-base-3 rounded-tr-none'
+                    : 'border-base-2 bg-base-3 text-base-0 rounded-tl-none border',
+                )}
+              >
+                {message.content.replace(/\*\*/g, '') || (
+                  // 로딩 애니메이션
+                  <div className="flex items-center justify-center gap-1 py-1">
+                    <span className="bg-base-1 h-1.5 w-1.5 animate-bounce rounded-full [animation-delay:0ms]" />
+                    <span className="bg-base-1 h-1.5 w-1.5 animate-bounce rounded-full [animation-delay:150ms]" />
+                    <span className="bg-base-1 h-1.5 w-1.5 animate-bounce rounded-full [animation-delay:300ms]" />
+                  </div>
+                )}
+              </div>
+            )}
           </div>
         ))}
         <div ref={scrollRef} />
       </div>
 
-      {/* 풋터 입력 바 */}
+      {/* 객관식 칩 영역 */}
+      <div className="border-base-2 bg-base-3 border-t px-3 py-3">
+        {deckLoading ? (
+          <p className="text-base-1 text-center text-sm">현재 덱을 읽는 중입니다...</p>
+        ) : pickerOpen ? (
+          <div className="flex flex-col gap-2">
+            <div className="flex items-center justify-between">
+              <span className="text-base-1 text-xs font-semibold">타입을 선택하세요</span>
+              <button type="button" onClick={() => setPickerOpen(false)} className="text-base-1 text-xs font-semibold">
+                뒤로
+              </button>
+            </div>
+            <div className="grid grid-cols-6 gap-1.5">
+              {TYPE_OPTIONS.map(({ type, label }) => (
+                <button
+                  key={type}
+                  type="button"
+                  disabled={busy}
+                  onClick={() =>
+                    runSuggestion(`${label} 타입 덱 추천해줘`, `${label} 타입 덱`, () => recommendTypeDeck(type))
+                  }
+                  className="bg-base-2 text-base-0 hover:bg-primary hover:text-base-3 rounded-md py-1.5 text-xs font-semibold transition-colors disabled:opacity-40"
+                >
+                  {label}
+                </button>
+              ))}
+            </div>
+          </div>
+        ) : (
+          <div className="flex flex-col gap-2">
+            <span className="text-base-1 text-xs font-semibold">어떤 덱을 추천해드릴까요?</span>
+            <div className="flex flex-wrap gap-1.5">
+              <ChipButton
+                disabled={busy}
+                onClick={() =>
+                  runSuggestion('이 층 카운터 덱 추천해줘', `${currentFloor}층 카운터 덱`, () =>
+                    recommendCounterDeck(currentFloor),
+                  )
+                }
+              >
+                이 층 카운터 덱
+              </ChipButton>
+              <ChipButton disabled={busy} onClick={() => setPickerOpen(true)}>
+                특정 타입 덱
+              </ChipButton>
+              <ChipButton
+                disabled={busy || !entryReady}
+                title={!entryReady ? entryHint : undefined}
+                onClick={() =>
+                  runSuggestion('내 등록 덱 분석해줘', '내 등록 덱 분석', () => analyzeEntryDeck(currentFloor))
+                }
+              >
+                내 등록 덱 분석
+              </ChipButton>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* 풋터 입력 바 (직접 입력) */}
       <form onSubmit={handleSubmit} className="border-base-2 bg-base-3 flex items-center gap-2 border-t p-3">
         <input
           type="text"
           value={input}
           onChange={(e) => setInput(e.target.value)}
-          placeholder={isTyping ? 'AI가 생각하는 중입니다...' : '카운터 카드 조합 물어보기'}
-          disabled={isTyping}
+          placeholder={busy ? 'AI가 생각하는 중입니다...' : '직접 입력해 물어보기'}
+          disabled={busy}
           className="bg-base-2 text-base-0 placeholder:text-base-1 focus:border-primary focus:bg-base-3 flex-1 rounded-xl border border-transparent px-4 py-2.5 text-sm transition-all focus:outline-none"
         />
         <button
           type="submit"
-          disabled={!input.trim() || isTyping}
+          disabled={!input.trim() || busy}
           className="bg-primary text-base-3 h-10 w-11 shrink-0 rounded-xl text-sm font-bold disabled:cursor-not-allowed disabled:opacity-50"
         >
           전송
         </button>
       </form>
     </div>
+  );
+}
+
+function ChipButton({
+  children,
+  onClick,
+  disabled,
+  title,
+}: {
+  children: React.ReactNode;
+  onClick: () => void;
+  disabled?: boolean;
+  title?: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      title={title}
+      className="border-base-2 text-base-0 hover:bg-primary hover:text-base-3 hover:border-primary rounded-full border px-3 py-1.5 text-xs font-semibold transition-colors disabled:cursor-not-allowed disabled:opacity-40"
+    >
+      {children}
+    </button>
   );
 }

--- a/src/features/chat/actions.ts
+++ b/src/features/chat/actions.ts
@@ -1,13 +1,19 @@
 'use server';
 
+import { generateText, streamText } from 'ai';
 import { createOllama } from 'ollama-ai-provider-v2';
-import { streamText } from 'ai';
 
+import { typeLabelMap } from '@/app/(main)/(start)/build-deck/_constants/pokemon-type';
+import { filterByType, filterTowerCounter } from '@/features/deck-recommendation/lib/rule-engine';
+import { buildRoster, loadOwnedRoster } from '@/features/deck-recommendation/lib/roster';
 import { TOWER_FLOORS } from '@/shared/config/tower-floors';
 import { createClient } from '@/shared/lib/supabase/server';
 
+import type { RosterPokemon } from '@/features/deck-recommendation/model/schemas';
 import type { PokemonType } from '@/shared/types/pokemon';
 import type { ChatMessage } from '@/shared/stores/overlay-store';
+
+import { TYPE_CHART } from '../../../data/type-chart';
 
 const LLM_BASE_URL = process.env.LLM_BASE_URL ?? 'http://localhost:11434/api';
 const LLM_CHAT_MODEL = process.env.LLM_CHAT_MODEL ?? 'qwen2.5:7b';
@@ -78,6 +84,212 @@ export async function copyCounterDeckToUser(dexIds: number[]) {
   return { success: true, deckId: deck.id, message: '카운터 덱이 성공적으로 복사되었습니다.' };
 }
 
+export type EntryDeckPokemon = {
+  dexId: number;
+  koName: string;
+  artworkUrl: string;
+  type1: PokemonType;
+  type2: PokemonType | null;
+};
+
+export type EntryDeckResult = { ok: true; deck: EntryDeckPokemon[] } | { ok: false; message: string };
+
+// 유저가 등록한 6마리 엔트리 덱(pokedex_entries)을 등록 순서대로 불러온다
+export async function loadEntryDeck(): Promise<EntryDeckResult> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) return { ok: false, message: '로그인이 필요합니다' };
+
+  const { data: entries } = await supabase
+    .from('pokedex_entries')
+    .select('dex_id')
+    .eq('user_id', user.id)
+    .order('discovered_at', { ascending: true });
+
+  if (!entries || entries.length === 0) {
+    return { ok: false, message: '등록된 덱이 없습니다. 도감에서 6마리를 먼저 등록해 주세요.' };
+  }
+
+  const dexIds = [...new Set(entries.map((e: { dex_id: number }) => e.dex_id))];
+
+  const { data: species } = await supabase
+    .from('pokemon_species')
+    .select('dex_id, ko_name, artwork_url, type1_id, type2_id')
+    .in('dex_id', dexIds);
+
+  if (!species || species.length === 0) {
+    return { ok: false, message: '덱 정보를 불러오지 못했습니다' };
+  }
+
+  const byId = new Map(
+    species.map(
+      (s: {
+        dex_id: number;
+        ko_name: string;
+        artwork_url: string | null;
+        type1_id: PokemonType;
+        type2_id: PokemonType | null;
+      }) => [s.dex_id, s] as const,
+    ),
+  );
+
+  const deck = dexIds
+    .map((id) => byId.get(id))
+    .filter((s): s is NonNullable<typeof s> => Boolean(s))
+    .map((s) => ({
+      dexId: s.dex_id,
+      koName: s.ko_name,
+      artworkUrl: s.artwork_url ?? '',
+      type1: s.type1_id,
+      type2: s.type2_id,
+    }));
+
+  return { ok: true, deck };
+}
+
+const DECK_SIZE = 6;
+
+export type DeckSuggestion =
+  | { ok: true; deck: { dexId: number; koName: string; artworkUrl: string }[]; explanation: string }
+  | { ok: false; message: string };
+
+function toDeckSlots(roster: RosterPokemon[]) {
+  return roster.slice(0, DECK_SIZE).map((p) => ({ dexId: p.dexId, koName: p.koName, artworkUrl: p.artworkUrl }));
+}
+
+// 현재 층의 적 타입 집합을 TOWER_FLOORS 풀에서 도출한다
+async function getFloorEnemyTypes(
+  supabase: Awaited<ReturnType<typeof createClient>>,
+  floor: number,
+): Promise<PokemonType[]> {
+  const config = TOWER_FLOORS.find((f) => f.floor === floor);
+  if (!config || config.pokemonPool.length === 0) return [];
+
+  const { data: species } = await supabase
+    .from('pokemon_species')
+    .select('type1_id, type2_id')
+    .in('dex_id', config.pokemonPool);
+
+  if (!species) return [];
+
+  const types = new Set<PokemonType>();
+  for (const s of species as { type1_id: PokemonType; type2_id: PokemonType | null }[]) {
+    types.add(s.type1_id);
+    if (s.type2_id) types.add(s.type2_id);
+  }
+  return [...types];
+}
+
+const EXPLAIN_SYSTEM_PROMPT = `너는 PODECK 무한의 탑 공략 조력자다. 주어진 덱과 상황을 바탕으로 추천 근거를 한국어로 2~3문장 안에 짧게 설명해라.
+규칙: 한국어만 사용하고 영어 단어·마크다운(**, #)·이모지를 절대 쓰지 마라. 포켓몬 타입은 반드시 한글(불꽃, 물, 독 등)로 표기해라. 타입 상성을 중심으로 왜 이 구성이 유리한지만 담백하게 말하고, 각 문장은 줄바꿈으로 구분해라.`;
+
+// 확정된 덱에 대한 짧은 설명만 LLM으로 생성한다 (덱 선정 자체는 결정론)
+async function explainDeck(prompt: string): Promise<string> {
+  try {
+    const { text } = await generateText({ model: llm(LLM_CHAT_MODEL), system: EXPLAIN_SYSTEM_PROMPT, prompt });
+    return text
+      .replace(/\*\*/g, '')
+      .replace(/([.!?])\s+/g, '$1\n')
+      .trim();
+  } catch (error) {
+    console.error('덱 설명 생성 실패:', error);
+    return '';
+  }
+}
+
+// 객관식 1. 현재 층을 카운터하는 덱 (보유 포켓몬 전체에서 선발)
+export async function recommendCounterDeck(currentFloor: number): Promise<DeckSuggestion> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return { ok: false, message: '로그인이 필요합니다' };
+
+  const roster = await loadOwnedRoster(supabase, user.id);
+  if (roster.length < 3) return { ok: false, message: '추천을 받으려면 보유 포켓몬이 최소 3마리 필요합니다' };
+
+  const enemyTypes = await getFloorEnemyTypes(supabase, currentFloor);
+  const ranked = await filterTowerCounter(roster, enemyTypes);
+  const deck = toDeckSlots(ranked);
+
+  const enemyLabel = enemyTypes.length > 0 ? enemyTypes.map((t) => typeLabelMap[t] ?? t).join(', ') : '정보 없음';
+  const explanation = await explainDeck(
+    `현재 ${currentFloor}층 적 타입: [${enemyLabel}]. 추천 카운터 덱: ${deck.map((d) => d.koName).join(', ')}. 이 덱이 왜 이 층에 유리한지 설명해줘.`,
+  );
+
+  return { ok: true, deck, explanation };
+}
+
+// 객관식 2. 특정 타입으로 구성된 덱 (보유 포켓몬 중 해당 타입)
+export async function recommendTypeDeck(type: PokemonType): Promise<DeckSuggestion> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return { ok: false, message: '로그인이 필요합니다' };
+
+  const roster = await loadOwnedRoster(supabase, user.id);
+  const candidates = filterByType(roster, type);
+  if (candidates.length === 0) return { ok: false, message: '해당 타입의 보유 포켓몬이 없습니다' };
+
+  const deck = toDeckSlots(candidates);
+  const explanation = await explainDeck(
+    `${typeLabelMap[type] ?? type} 타입으로 구성한 덱: ${deck.map((d) => d.koName).join(', ')}. 이 타입 덱의 강점과 운영 방향을 설명해줘.`,
+  );
+
+  return { ok: true, deck, explanation };
+}
+
+// 객관식 3. 내 등록 덱(pokedex_entries)이 현재 층에 통할지 결정론으로 분석한다 (0토큰)
+export async function analyzeEntryDeck(currentFloor: number): Promise<DeckSuggestion> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return { ok: false, message: '로그인이 필요합니다' };
+
+  const { data: entries } = await supabase
+    .from('pokedex_entries')
+    .select('dex_id')
+    .eq('user_id', user.id)
+    .order('discovered_at', { ascending: true });
+
+  if (!entries || entries.length === 0) {
+    return { ok: false, message: '등록된 덱이 없습니다. 도감에서 6마리를 먼저 등록해 주세요.' };
+  }
+
+  const roster = await buildRoster(
+    supabase,
+    entries.map((e: { dex_id: number }) => e.dex_id),
+  );
+  const enemyTypes = await getFloorEnemyTypes(supabase, currentFloor);
+
+  const advantaged: string[] = [];
+  const weak: string[] = [];
+  for (const p of roster) {
+    const hasSuperEffectiveMove = p.moves.some(
+      (m) => m.power !== null && enemyTypes.some((et) => (TYPE_CHART[m.type]?.[et] ?? 1) >= 2),
+    );
+    const isVulnerable = enemyTypes.some(
+      (et) => (TYPE_CHART[et]?.[p.type1] ?? 1) >= 2 || (p.type2 ? (TYPE_CHART[et]?.[p.type2] ?? 1) >= 2 : false),
+    );
+    if (hasSuperEffectiveMove && !isVulnerable) advantaged.push(p.koName);
+    else if (isVulnerable && !hasSuperEffectiveMove) weak.push(p.koName);
+  }
+
+  const enemyLabel = enemyTypes.length > 0 ? enemyTypes.map((t) => typeLabelMap[t] ?? t).join(', ') : '정보 없음';
+  const lines = [
+    `현재 ${currentFloor}층 적 타입: ${enemyLabel}`,
+    advantaged.length > 0 ? `유리한 카드: ${advantaged.join(', ')}` : '뚜렷하게 유리한 카드: 없음',
+    weak.length > 0 ? `불리한 카드: ${weak.join(', ')}` : '불리한 카드: 없음',
+  ];
+
+  return { ok: true, deck: toDeckSlots(roster), explanation: lines.join('\n') };
+}
+
 // 채팅 스트리밍 응답 생성
 export async function streamChatResponse(messages: ChatMessage[], currentFloor: number) {
   const supabase = await createClient();
@@ -97,7 +309,8 @@ export async function streamChatResponse(messages: ChatMessage[], currentFloor: 
         .map((row) => normalizeEnemySpecies(row))
         .filter((s): s is EnemySpecies => s !== null)
         .map((s) => {
-          const types = s.type2_id ? `${s.type1_id}/${s.type2_id}` : s.type1_id;
+          const t1 = typeLabelMap[s.type1_id] ?? s.type1_id;
+          const types = s.type2_id ? `${t1}/${typeLabelMap[s.type2_id] ?? s.type2_id}` : t1;
           return `- ${s.ko_name} [${types}] (체력:${s.base_hp} 공격:${s.base_atk} 방어:${s.base_def})`;
         })
         .join('\n');

--- a/src/features/chat/actions.ts
+++ b/src/features/chat/actions.ts
@@ -6,7 +6,6 @@ import { createOllama } from 'ollama-ai-provider-v2';
 import { typeLabelMap } from '@/app/(main)/(start)/build-deck/_constants/pokemon-type';
 import { filterByType, filterTowerCounter } from '@/features/deck-recommendation/lib/rule-engine';
 import { buildRoster, loadOwnedRoster } from '@/features/deck-recommendation/lib/roster';
-import { TOWER_FLOORS } from '@/shared/config/tower-floors';
 import { createClient } from '@/shared/lib/supabase/server';
 
 import type { RosterPokemon } from '@/features/deck-recommendation/model/schemas';
@@ -160,18 +159,26 @@ function toDeckSlots(roster: RosterPokemon[]) {
   return roster.slice(0, DECK_SIZE).map((p) => ({ dexId: p.dexId, koName: p.koName, artworkUrl: p.artworkUrl }));
 }
 
-// 현재 층의 적 타입 집합을 TOWER_FLOORS 풀에서 도출한다
+// 현재 층 적 dex_id 목록을 DB(tower_floors.pokemon_pool)에서 읽는다
+async function getFloorEnemyDexIds(
+  supabase: Awaited<ReturnType<typeof createClient>>,
+  floor: number,
+): Promise<number[]> {
+  const { data } = await supabase.from('tower_floors').select('pokemon_pool').eq('floor', floor).maybeSingle();
+  const pool = (data?.pokemon_pool ?? null) as { enemies?: { dexId: number }[] } | null;
+  if (!pool?.enemies) return [];
+  return [...new Set(pool.enemies.map((e) => e.dexId).filter((id): id is number => typeof id === 'number'))];
+}
+
+// 현재 층의 적 타입 집합을 DB 로스터에서 도출한다
 async function getFloorEnemyTypes(
   supabase: Awaited<ReturnType<typeof createClient>>,
   floor: number,
 ): Promise<PokemonType[]> {
-  const config = TOWER_FLOORS.find((f) => f.floor === floor);
-  if (!config || config.pokemonPool.length === 0) return [];
+  const dexIds = await getFloorEnemyDexIds(supabase, floor);
+  if (dexIds.length === 0) return [];
 
-  const { data: species } = await supabase
-    .from('pokemon_species')
-    .select('type1_id, type2_id')
-    .in('dex_id', config.pokemonPool);
+  const { data: species } = await supabase.from('pokemon_species').select('type1_id, type2_id').in('dex_id', dexIds);
 
   if (!species) return [];
 
@@ -294,15 +301,15 @@ export async function analyzeEntryDeck(currentFloor: number): Promise<DeckSugges
 export async function streamChatResponse(messages: ChatMessage[], currentFloor: number) {
   const supabase = await createClient();
 
-  // 적 정보는 TOWER_FLOORS 설정의 pokemonPool(dex ID 배열)을 기준으로 species를 조회한다
-  const floorConfig = TOWER_FLOORS.find((f) => f.floor === currentFloor);
+  // 적 정보는 DB(tower_floors.pokemon_pool)의 dex ID를 기준으로 species를 조회한다
+  const enemyDexIds = await getFloorEnemyDexIds(supabase, currentFloor);
 
   let enemyContext = '정보 없음';
-  if (floorConfig && floorConfig.pokemonPool.length > 0) {
+  if (enemyDexIds.length > 0) {
     const { data: enemies } = await supabase
       .from('pokemon_species')
       .select('ko_name, type1_id, type2_id, base_hp, base_atk, base_def')
-      .in('dex_id', floorConfig.pokemonPool);
+      .in('dex_id', enemyDexIds);
 
     if (enemies && enemies.length > 0) {
       enemyContext = enemies
@@ -319,21 +326,21 @@ export async function streamChatResponse(messages: ChatMessage[], currentFloor: 
 
   const CHAT_SYSTEM_PROMPT = `너는 PODECK 게임의 무한의 탑 공략 전문 배틀 AI 조력자다.
 현재 플레이어가 도전 중인 층은 [무한의 탑 ${currentFloor}층]이다.
-현재 층의 적 정보는 [${enemyContext}]이다.
+현재 층의 적 로스터(이름 / 타입 / 능력치)는 다음과 같다:
+${enemyContext}
 
-답변 원칙 (절대 사수):
-1. 처음부터 끝까지 모든 문장을 완벽한 "한국어"로만 답변해라. 영어 단어(예: HP, Burn, Card Draw 등)를 영어 그대로 노출하지 말고 '체력', '화상 데미지', '카드 뽑기'와 같이 한글로 번역해서 말해라.
-2. 친절하면서도 예리한 턴제 카드 게임 스트리머나 프로게이머처럼 말해라.
-3. 가장 위협적인 적 1~2개를 기준으로 핵심 약점 타입과 조심해야 할 스펙을 짚어라.
-4. 서론, 인사, 맺음말 없이 곧바로 핵심만 말해라. 각 항목은 한 문장으로 짧게 끊어라.
-5. 답변은 아래 형식 그대로, 세 줄로 나눠서(각 항목 사이 줄바꿈 필수) 출력해라:
+답변 원칙:
+1. 무엇보다 사용자의 질문에 직접 답해라. 위에 주어진 적 로스터 정보 안에서만 답하고, 없는 정보는 절대 지어내지 마라.
+2. 사용자가 적 목록·이름·타입·능력치를 물으면, 위 로스터의 포켓몬 이름과 타입을 한 줄에 하나씩 그대로 나열해라.
+3. 사용자가 공략·카운터·전략을 물을 때만 아래 형식으로 답해라(각 항목 줄바꿈 필수):
 약점 타입: (내용)
 위험 요소: (내용)
 운영 팁: (내용)
+4. 친절하지만 장황하지 않게, 서론·맺음말 없이 핵심만 짧게 답하고 각 문장은 줄바꿈으로 구분해라.
 
-텍스트 스타일 규칙 (필수):
-- ** 기호나 # 같은 마크다운 특수문자를 절대 사용하지 마라. (예: "**약점 타입**" 대신 "약점 타입:" 처럼 순수 텍스트만 쓸 것)
-- 주사위(🎲), 웃음(😄) 같은 이모지나 특수 아이콘을 절대 포함하지 말고 담백하게 글자로만 출력해라.`;
+스타일 규칙(필수):
+- 모든 문장을 완벽한 한국어로만 써라. 영어 단어(HP, Burn 등)는 '체력', '화상'처럼 한글로 바꾸고, 포켓몬 타입도 반드시 한글(불꽃, 물, 노말 등)로 표기해라.
+- 마크다운 기호(**, #)나 이모지를 절대 쓰지 말고 담백한 글자로만 출력해라.`;
 
   const result = await streamText({
     model: llm(LLM_CHAT_MODEL),

--- a/src/features/chat/actions.ts
+++ b/src/features/chat/actions.ts
@@ -1,7 +1,7 @@
 'use server';
 
+import { google } from '@ai-sdk/google';
 import { generateText, streamText } from 'ai';
-import { createOllama } from 'ollama-ai-provider-v2';
 
 import { typeLabelMap } from '@/app/(main)/(start)/build-deck/_constants/pokemon-type';
 import { filterByType, filterTowerCounter } from '@/features/deck-recommendation/lib/rule-engine';
@@ -14,12 +14,7 @@ import type { ChatMessage } from '@/shared/stores/overlay-store';
 
 import { TYPE_CHART } from '../../../data/type-chart';
 
-const LLM_BASE_URL = process.env.LLM_BASE_URL ?? 'http://localhost:11434/api';
-const LLM_CHAT_MODEL = process.env.LLM_CHAT_MODEL ?? 'qwen2.5:7b';
-
-const llm = createOllama({
-  baseURL: LLM_BASE_URL,
-});
+const LLM_CHAT_MODEL = process.env.LLM_CHAT_MODEL ?? 'gemini-2.5-flash';
 
 type EnemySpecies = {
   ko_name: string;
@@ -196,7 +191,7 @@ const EXPLAIN_SYSTEM_PROMPT = `너는 PODECK 무한의 탑 공략 조력자다. 
 // 확정된 덱에 대한 짧은 설명만 LLM으로 생성한다 (덱 선정 자체는 결정론)
 async function explainDeck(prompt: string): Promise<string> {
   try {
-    const { text } = await generateText({ model: llm(LLM_CHAT_MODEL), system: EXPLAIN_SYSTEM_PROMPT, prompt });
+    const { text } = await generateText({ model: google(LLM_CHAT_MODEL), system: EXPLAIN_SYSTEM_PROMPT, prompt });
     return text
       .replace(/\*\*/g, '')
       .replace(/([.!?])\s+/g, '$1\n')
@@ -343,7 +338,7 @@ ${enemyContext}
 - 마크다운 기호(**, #)나 이모지를 절대 쓰지 말고 담백한 글자로만 출력해라.`;
 
   const result = await streamText({
-    model: llm(LLM_CHAT_MODEL),
+    model: google(LLM_CHAT_MODEL),
     system: CHAT_SYSTEM_PROMPT,
     messages: messages.map((msg) => ({
       role: msg.role,

--- a/src/features/chat/actions.ts
+++ b/src/features/chat/actions.ts
@@ -1,7 +1,7 @@
 'use server';
 
-import { google } from '@ai-sdk/google';
 import { generateText, streamText } from 'ai';
+import { createOllama } from 'ollama-ai-provider-v2';
 
 import { typeLabelMap } from '@/app/(main)/(start)/build-deck/_constants/pokemon-type';
 import { filterByType, filterTowerCounter } from '@/features/deck-recommendation/lib/rule-engine';
@@ -14,7 +14,15 @@ import type { ChatMessage } from '@/shared/stores/overlay-store';
 
 import { TYPE_CHART } from '../../../data/type-chart';
 
-const LLM_CHAT_MODEL = process.env.LLM_CHAT_MODEL ?? 'gemini-2.5-flash';
+const LLM_BASE_URL = process.env.LLM_BASE_URL ?? 'http://localhost:11434/api';
+const LLM_CHAT_MODEL = process.env.LLM_CHAT_MODEL ?? 'exaone3.5:7.8b';
+const LLM_API_KEY = process.env.LLM_API_KEY;
+
+const llm = createOllama({
+  baseURL: LLM_BASE_URL,
+  // 원격 Ollama(EC2)는 프록시에서 Bearer 토큰을 검증한다. 로컬은 키가 없어 헤더 미전송.
+  headers: LLM_API_KEY ? { Authorization: `Bearer ${LLM_API_KEY}` } : undefined,
+});
 
 type EnemySpecies = {
   ko_name: string;
@@ -191,7 +199,7 @@ const EXPLAIN_SYSTEM_PROMPT = `너는 PODECK 무한의 탑 공략 조력자다. 
 // 확정된 덱에 대한 짧은 설명만 LLM으로 생성한다 (덱 선정 자체는 결정론)
 async function explainDeck(prompt: string): Promise<string> {
   try {
-    const { text } = await generateText({ model: google(LLM_CHAT_MODEL), system: EXPLAIN_SYSTEM_PROMPT, prompt });
+    const { text } = await generateText({ model: llm(LLM_CHAT_MODEL), system: EXPLAIN_SYSTEM_PROMPT, prompt });
     return text
       .replace(/\*\*/g, '')
       .replace(/([.!?])\s+/g, '$1\n')
@@ -338,7 +346,7 @@ ${enemyContext}
 - 마크다운 기호(**, #)나 이모지를 절대 쓰지 말고 담백한 글자로만 출력해라.`;
 
   const result = await streamText({
-    model: google(LLM_CHAT_MODEL),
+    model: llm(LLM_CHAT_MODEL),
     system: CHAT_SYSTEM_PROMPT,
     messages: messages.map((msg) => ({
       role: msg.role,

--- a/src/features/deck-recommendation/actions/recommendDeck.ts
+++ b/src/features/deck-recommendation/actions/recommendDeck.ts
@@ -1,7 +1,6 @@
 'use server';
 
 import { createClient } from '@/shared/lib/supabase/server';
-import type { PokemonType } from '@/shared/types/pokemon';
 import { RecommendRequestSchema } from '../model/schemas';
 import type { RecommendedDeck, RecommendResponse, RosterPokemon } from '../model/schemas';
 import {
@@ -12,6 +11,7 @@ import {
   filterSpeed,
   filterCounter,
 } from '../lib/rule-engine';
+import { loadOwnedRoster } from '../lib/roster';
 import { generateRecommendation, RECOMMENDATION_MODEL } from '../lib/gemini';
 import { fallbackRecommendation } from '../lib/fallback';
 import {
@@ -21,79 +21,6 @@ import {
   setCachedRecommendation,
   checkRateLimit,
 } from '../lib/cache';
-import rawMovesJson from '../../../../data/moves.json';
-import rawPokemonMovesJson from '../../../../data/pokemon-moves.json';
-
-type MoveEntry = {
-  id: string;
-  koName: string;
-  type: string;
-  damageClass: string;
-  power: number;
-  accuracy: number;
-  pp: number;
-};
-
-const movesData = rawMovesJson as Record<string, MoveEntry>;
-const pokemonMovesData = rawPokemonMovesJson as Record<string, string[]>;
-
-async function loadRoster(
-  supabase: Awaited<ReturnType<typeof createClient>>,
-  userId: string,
-): Promise<RosterPokemon[]> {
-  const { data: trainerPokemons } = await supabase.from('owned_pokemon').select('dex_id').eq('user_id', userId);
-
-  if (!trainerPokemons || trainerPokemons.length === 0) return [];
-
-  // 같은 종을 여러 마리 보유할 수 있으므로 dex_id 중복 제거
-  const dexIds = [...new Set(trainerPokemons.map((p: { dex_id: number }) => p.dex_id))];
-
-  const { data: species } = await supabase
-    .from('pokemon_species')
-    .select('dex_id, ko_name, artwork_url, type1_id, type2_id, base_hp, base_atk, base_def, base_spd')
-    .in('dex_id', dexIds);
-
-  if (!species) return [];
-
-  return species.map(
-    (s: {
-      dex_id: number;
-      ko_name: string;
-      artwork_url: string | null;
-      type1_id: PokemonType;
-      type2_id: PokemonType | null;
-      base_hp: number;
-      base_atk: number;
-      base_def: number;
-      base_spd: number;
-    }) => {
-      const moveIds = pokemonMovesData[String(s.dex_id)] ?? [];
-      const moves = moveIds.slice(0, 4).map((id) => {
-        const m = movesData[id];
-        return {
-          id,
-          koName: m?.koName ?? id,
-          type: (m?.type ?? 'normal') as PokemonType,
-          power: m && m.power > 0 ? m.power : null,
-          statusEffect: m?.damageClass === 'status' ? 'status' : null,
-        };
-      });
-
-      return {
-        dexId: s.dex_id,
-        koName: s.ko_name,
-        artworkUrl: s.artwork_url ?? '',
-        type1: s.type1_id,
-        type2: s.type2_id,
-        level: 1,
-        baseAtk: s.base_atk,
-        baseSpd: s.base_spd,
-        baseStatTotal: s.base_hp + s.base_atk + s.base_def + s.base_spd,
-        moves,
-      };
-    },
-  );
-}
 
 function trimDesc(deck: RecommendedDeck): RecommendedDeck {
   return deck.description.length <= 14 ? deck : { ...deck, description: deck.description.slice(0, 14) };
@@ -117,7 +44,7 @@ export async function recommendDeck(rawInput: unknown): Promise<RecommendRespons
     return { ok: false, message: '로그인이 필요합니다' };
   }
 
-  const roster = await loadRoster(supabase, user.id);
+  const roster = await loadOwnedRoster(supabase, user.id);
 
   if (roster.length < 3) {
     return { ok: false, message: '추천을 받으려면 최소 3마리의 포켓몬이 필요합니다' };
@@ -223,7 +150,7 @@ export async function recommendHomeDecks(): Promise<HomeDecksResponse> {
   const err: RecommendResponse = { ok: false, message: '로그인이 필요합니다' };
   if (!user) return { decks: [err, err] };
 
-  const roster = await loadRoster(supabase, user.id);
+  const roster = await loadOwnedRoster(supabase, user.id);
 
   if (roster.length < 3) {
     const e: RecommendResponse = { ok: false, message: '추천을 받으려면 최소 3마리의 포켓몬이 필요합니다' };

--- a/src/features/deck-recommendation/lib/gemini.ts
+++ b/src/features/deck-recommendation/lib/gemini.ts
@@ -13,7 +13,7 @@ const AiDeckSchema = z.object({
   strategy: z.string(),
 });
 
-export const RECOMMENDATION_MODEL = 'gemini-2.0-flash';
+export const RECOMMENDATION_MODEL = 'gemini-2.5-flash';
 
 const model = google(RECOMMENDATION_MODEL);
 

--- a/src/features/deck-recommendation/lib/roster.ts
+++ b/src/features/deck-recommendation/lib/roster.ts
@@ -24,11 +24,12 @@ export async function buildRoster(supabase: SupabaseClient, dexIds: number[]): P
   const unique = [...new Set(dexIds)];
   if (unique.length === 0) return [];
 
-  const { data: species } = await supabase
+  const { data: species, error: speciesError } = await supabase
     .from('pokemon_species')
     .select('dex_id, ko_name, artwork_url, type1_id, type2_id, base_hp, base_atk, base_def, base_spd')
     .in('dex_id', unique);
 
+  if (speciesError) throw new Error(`pokemon_species 조회 실패: ${speciesError.message}`);
   if (!species) return [];
 
   return species.map(

--- a/src/features/deck-recommendation/lib/roster.ts
+++ b/src/features/deck-recommendation/lib/roster.ts
@@ -1,0 +1,82 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+import type { PokemonType } from '@/shared/types/pokemon';
+
+import type { RosterPokemon } from '../model/schemas';
+import rawMovesJson from '../../../../data/moves.json';
+import rawPokemonMovesJson from '../../../../data/pokemon-moves.json';
+
+type MoveEntry = {
+  id: string;
+  koName: string;
+  type: string;
+  damageClass: string;
+  power: number;
+  accuracy: number;
+  pp: number;
+};
+
+const movesData = rawMovesJson as Record<string, MoveEntry>;
+const pokemonMovesData = rawPokemonMovesJson as Record<string, string[]>;
+
+// dex_id 목록을 pokemon_species + 기술 데이터와 조인해 RosterPokemon[]으로 빌드한다
+export async function buildRoster(supabase: SupabaseClient, dexIds: number[]): Promise<RosterPokemon[]> {
+  const unique = [...new Set(dexIds)];
+  if (unique.length === 0) return [];
+
+  const { data: species } = await supabase
+    .from('pokemon_species')
+    .select('dex_id, ko_name, artwork_url, type1_id, type2_id, base_hp, base_atk, base_def, base_spd')
+    .in('dex_id', unique);
+
+  if (!species) return [];
+
+  return species.map(
+    (s: {
+      dex_id: number;
+      ko_name: string;
+      artwork_url: string | null;
+      type1_id: PokemonType;
+      type2_id: PokemonType | null;
+      base_hp: number;
+      base_atk: number;
+      base_def: number;
+      base_spd: number;
+    }) => {
+      const moveIds = pokemonMovesData[String(s.dex_id)] ?? [];
+      const moves = moveIds.slice(0, 4).map((id) => {
+        const m = movesData[id];
+        return {
+          id,
+          koName: m?.koName ?? id,
+          type: (m?.type ?? 'normal') as PokemonType,
+          power: m && m.power > 0 ? m.power : null,
+          statusEffect: m?.damageClass === 'status' ? 'status' : null,
+        };
+      });
+
+      return {
+        dexId: s.dex_id,
+        koName: s.ko_name,
+        artworkUrl: s.artwork_url ?? '',
+        type1: s.type1_id,
+        type2: s.type2_id,
+        level: 1,
+        baseAtk: s.base_atk,
+        baseSpd: s.base_spd,
+        baseStatTotal: s.base_hp + s.base_atk + s.base_def + s.base_spd,
+        moves,
+      };
+    },
+  );
+}
+
+// 유저가 보유한 포켓몬 전체(owned_pokemon)를 로스터로 빌드한다
+export async function loadOwnedRoster(supabase: SupabaseClient, userId: string): Promise<RosterPokemon[]> {
+  const { data } = await supabase.from('owned_pokemon').select('dex_id').eq('user_id', userId);
+  if (!data || data.length === 0) return [];
+  return buildRoster(
+    supabase,
+    data.map((p: { dex_id: number }) => p.dex_id),
+  );
+}

--- a/src/features/deck-recommendation/lib/rule-engine.ts
+++ b/src/features/deck-recommendation/lib/rule-engine.ts
@@ -11,10 +11,7 @@ async function ensureTypeChart(): Promise<TypeChartCache> {
   if (typeChartCache) return typeChartCache;
 
   const supabase = await createClient();
-  const { data, error } = await supabase
-    .from('type_charts')
-    .select('attack_type_id, defense_type_id, multiplier')
-    .throwOnError();
+  const { data, error } = await supabase.from('type_charts').select('attack_type_id, defense_type_id, multiplier');
 
   if (error || !data) {
     console.error('Type chart 데이터를 불러오는데 실패했습니다. 기본 상성 배율을 사용합니다.', error);
@@ -64,6 +61,13 @@ export function filterDefensive(roster: RosterPokemon[]): RosterPokemon[] {
 
 export function filterSpeed(roster: RosterPokemon[]): RosterPokemon[] {
   return [...roster].sort((a, b) => b.baseSpd - a.baseSpd).slice(0, CANDIDATE_LIMIT);
+}
+
+export function filterByType(roster: RosterPokemon[], type: PokemonType): RosterPokemon[] {
+  return roster
+    .filter((p) => p.type1 === type || p.type2 === type)
+    .sort((a, b) => b.baseStatTotal - a.baseStatTotal)
+    .slice(0, CANDIDATE_LIMIT);
 }
 
 export async function filterCounter(roster: RosterPokemon[], target: PokemonType): Promise<RosterPokemon[]> {

--- a/src/shared/stores/overlay-store.ts
+++ b/src/shared/stores/overlay-store.ts
@@ -1,8 +1,17 @@
 import { create } from 'zustand';
 
+export type ChatDeckSlot = {
+  dexId: number;
+  koName: string;
+  artworkUrl: string;
+};
+
 export type ChatMessage = {
   role: 'user' | 'assistant';
   content: string;
+  // 결정론 추천/분석 결과를 덱 카드로 렌더링할 때만 채워진다
+  title?: string;
+  deck?: ChatDeckSlot[];
 };
 
 type OverlayState = {


### PR DESCRIPTION
# Pull Request

## 🎯 작업 내용
무한의 탑 공략을 돕는 AI 챗봇 + 덱 추천(카운터 / 특정 타입 / 등록 덱 분석) 기능 구현

## 📌 작업 배경
- 무한의 탑 층별 공략 어시스턴트 필요
- 초기 Gemini 기반이었으나 free tier 종료로 로컬 LLM(Ollama)로 전환
- LLM 단독 추천은 타입/카드 환각이 심해, 게임 확정 데이터(타입 상성·층 로스터)를 결정론으로 계산하고 LLM은 설명만 담당하도록 설계

## 🔨 구현 내용
#### Added (추가)
- 객관식 칩 챗봇 UI: 이 층 카운터 덱 / 특정 타입 덱 / 내 등록 덱 분석 / 자유 입력
- 결정론 추천 server action: `recommendCounterDeck` `recommendTypeDeck` `analyzeEntryDeck`
- 공용 로스터 빌더(`buildRoster`/`loadOwnedRoster`), `filterByType`, `filterTowerCounter` 배선
- 등록 덱(`pokedex_entries`) 로딩 + pending UX
- 자유 입력 대상 층 지정(`N층`/`다음 층`) 및 현재+1층 상한 제한

#### Changed (변경)
- 챗봇 모델 Gemini → Ollama(qwen2.5 → EXAONE 3.5), 환경변수(`LLM_*`)로 분리
- 적 정보 출처: 정적 config → DB(`tower_floors.pokemon_pool`)
- 시스템 프롬프트: 질문 의도 적응형(로스터 나열 vs 전략 3줄), 한국어·한글 타입 강제, 줄바꿈

#### Fixed (수정)
- 스트림 소비 불일치(`textStream`)로 응답이 안 보이던 버그
- fallback 캐싱 누락으로 인한 무한 호출
- `any` 캐스팅 제거(타입 가드), import 순서·파일명 컨벤션 정리

## 📸 결과물

| 내용 / 영상 |
| :---: |
| <video src="https://github.com/user-attachments/assets/2828d252-43fb-49b6-9dcc-d79f03aaf0d6" width="400" controls style="display: block; margin: 0 auto;"></video> |
| **챗봇 시연 영상** |

## 🧪 테스트
- [x] 로컬 typecheck / lint 통과
- [x] 챗봇 각 칩, 자유입력 동작 (로컬 Exaone)
- [x] 층 상한, 로스터 조회, **한국어 출력** 확인

## 💬 리뷰 요청사항
- 적 정보 DB 출처 vs 배틀(config) 출처 불일치 → 배틀도 DB 정렬 필요(후속)
- "덱 사용하기"가 `pokedex_entries`가 아닌 `decks`/`deck_numbers`에 저장(미완)
- EXAONE 3.5 **비상업 라이선스** → 상업 배포 시 모델 재검토 필요

## 🔗 관련 링크
- Closes #62

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트
* **새로운 기능**
  * 채팅에서 층(Floor) 요청을 자동으로 해석해 응답을 맞춤 처리
  * 덱 추천/분석 결과를 카드 형태로 표시(선택·사용·복사·저장)
  * “내 등록 덱 분석” 진입 전 덱 로딩/안내 표시
* **개선 사항**
  * 추천/분석 중 입력·버튼 상태 제어 강화(로딩/비활성화)
  * 추천 근거와 한국어 출력 품질 개선, 보유 로스터 기반 추천 강화
* **문서/배포**
  * Ollama+Caddy 인증 프록시용 예시 설정/문서 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->