### PR TITLE
Fix: 구글 로그인 OAuth 흐름 안정화 (#74)

### DIFF
--- a/src/app/(auth)/auth/oauth/callback/route.ts
+++ b/src/app/(auth)/auth/oauth/callback/route.ts
@@ -25,6 +25,12 @@ export async function GET(request: NextRequest) {
   const { error } = await supabase.auth.exchangeCodeForSession(code);
 
   if (error) {
+    console.error('OAuth session exchange failed:', {
+      message: error.message,
+      status: error.status,
+      name: error.name,
+    });
+
     const {
       data: { user },
     } = await supabase.auth.getUser();

--- a/src/app/(auth)/login/_components/GoogleLoginButton.tsx
+++ b/src/app/(auth)/login/_components/GoogleLoginButton.tsx
@@ -1,20 +1,14 @@
 'use client';
 
 import { toast } from 'sonner';
-import { createClient } from '@/shared/lib/supabase/client';
+import { useGoogleLogin } from '@/features/auth/hooks/useGoogleLogin';
 import Image from 'next/image';
 
 export default function GoogleLoginButton() {
-  const handleGoogleLogin = async () => {
-    const supabase = createClient();
-    const origin = window.location.origin;
+  const { isLoading, loginWithGoogle } = useGoogleLogin();
 
-    const { error } = await supabase.auth.signInWithOAuth({
-      provider: 'google',
-      options: {
-        redirectTo: `${origin}/auth/oauth/callback`,
-      },
-    });
+  const handleGoogleLogin = async () => {
+    const error = await loginWithGoogle();
 
     if (error) {
       toast.error('Google 로그인에 실패했습니다');
@@ -24,8 +18,9 @@ export default function GoogleLoginButton() {
   return (
     <button
       type="button"
+      disabled={isLoading}
       onClick={handleGoogleLogin}
-      className="flex h-[50px] w-full items-center justify-center gap-3 rounded-[10px] bg-[#F2F2F2] font-bold text-[var(--color-base-0)] transition hover:opacity-90 active:scale-95"
+      className="flex h-[50px] w-full items-center justify-center gap-3 rounded-[10px] bg-[#F2F2F2] font-bold text-[var(--color-base-0)] transition hover:opacity-90 active:scale-95 disabled:cursor-not-allowed disabled:opacity-70 disabled:active:scale-100"
     >
       <Image src="/images/login/google-round.svg" alt="Google 로고" width={30} height={30} />
       Google로 계속하기

--- a/src/features/auth/hooks/useGoogleLogin.ts
+++ b/src/features/auth/hooks/useGoogleLogin.ts
@@ -1,0 +1,39 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+import type { AuthError } from '@supabase/supabase-js';
+import { createClient } from '@/shared/lib/supabase/client';
+
+export function createOAuthCallbackUrl(origin: string) {
+  return `${origin}/auth/oauth/callback`;
+}
+
+export function useGoogleLogin() {
+  const [isLoading, setIsLoading] = useState(false);
+
+  const loginWithGoogle = useCallback(async (): Promise<AuthError | null> => {
+    if (isLoading) return null;
+
+    setIsLoading(true);
+
+    const supabase = createClient();
+    const { error } = await supabase.auth.signInWithOAuth({
+      provider: 'google',
+      options: {
+        redirectTo: createOAuthCallbackUrl(window.location.origin),
+      },
+    });
+
+    if (error) {
+      setIsLoading(false);
+      return error;
+    }
+
+    return null;
+  }, [isLoading]);
+
+  return {
+    isLoading,
+    loginWithGoogle,
+  };
+}

--- a/test/auth/google-login.spec.ts
+++ b/test/auth/google-login.spec.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/shared/lib/supabase/client', () => ({
+  createClient: vi.fn(),
+}));
+
+import { createOAuthCallbackUrl } from '@/features/auth/hooks/useGoogleLogin';
+
+describe('createOAuthCallbackUrl', () => {
+  it('현재 origin 기준으로 OAuth callback URL을 만든다', () => {
+    expect(createOAuthCallbackUrl('https://podeck.vercel.app')).toBe('https://podeck.vercel.app/auth/oauth/callback');
+  });
+});

--- a/test/auth/oauth-callback.spec.ts
+++ b/test/auth/oauth-callback.spec.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const { exchangeCodeForSession, getOnboardingPath } = vi.hoisted(() => ({
+  exchangeCodeForSession: vi.fn(),
+  getOnboardingPath: vi.fn(),
+}));
+
+vi.mock('@/shared/lib/supabase/server', () => ({
+  createClient: vi.fn(async () => ({
+    auth: {
+      exchangeCodeForSession,
+      getUser: vi.fn(async () => ({ data: { user: null } })),
+    },
+  })),
+}));
+
+vi.mock('@/entities/trainer/api/trainerApi', () => ({
+  getOnboardingPath,
+}));
+
+import { GET } from '@/app/(auth)/auth/oauth/callback/route';
+
+describe('OAuth callback route', () => {
+  it('세션 교환 성공 후 홈 진입 대상이면 로딩 화면으로 리다이렉트한다', async () => {
+    exchangeCodeForSession.mockResolvedValueOnce({ error: null });
+    getOnboardingPath.mockResolvedValueOnce('/home');
+
+    const response = await GET(new Request('http://localhost:3000/auth/oauth/callback?code=test-code') as never);
+
+    expect(exchangeCodeForSession).toHaveBeenCalledWith('test-code');
+    expect(getOnboardingPath).toHaveBeenCalled();
+    expect(response.headers.get('location')).toBe('http://localhost:3000/loading');
+  });
+});


### PR DESCRIPTION
# Pull Request

## 🎯 작업 내용

구글 로그인 OAuth 흐름을 안정화하고 로그인 로직을 hook으로 분리했습니다.

## 📌 작업 배경

배포 환경에서 OAuth redirect URL 설정에 따라 로그인 흐름이 흔들릴 수 있었고, 로그인 버튼 컴포넌트 내부에 Supabase OAuth 호출 로직이 직접 포함되어 있어 유지보수성이 떨어졌습니다.

## 🔨 구현 내용

#### Added (추가)

- `useGoogleLogin` hook 추가
- OAuth callback URL 생성 로직 테스트 추가
- OAuth callback 성공 시 기존 `/loading` 진입 흐름을 검증하는 테스트 추가

#### Changed (변경)

- Google 로그인 버튼이 Supabase OAuth 호출을 직접 수행하지 않고 hook을 사용하도록 변경
- 로그인 진행 중 버튼을 비활성화해 중복 클릭을 방지하도록 변경

#### Fixed (수정)

- OAuth 세션 교환 실패 시 원인 확인이 가능하도록 서버 로그 추가
- 기존 로그인 성공 후 `/loading -> /home` 흐름이 유지되도록 callback redirect 동작 검증

## 📸 결과물

-

## 🧪 테스트

- [x] `pnpm vitest run test/auth/oauth-callback.spec.ts test/auth/google-login.spec.ts`
- [x] `pnpm run typecheck`

## 💬 리뷰 요청사항

- OAuth callback 실패 로그 수준과 메시지가 적절한지 확인 부탁드립니다.
- `useGoogleLogin` hook 분리 범위가 현재 로그인 구조에 적절한지 확인 부탁드립니다.

## 🔗 관련 링크

- Closes #74

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * Google 로그인 프로세스가 개선되었습니다.
  * 로그인 진행 중 버튼이 자동으로 비활성화되어 중복 요청을 방지합니다.
  * 세션 교환 실패 시 더 정확한 에러 로깅이 기록됩니다.

* **테스트**
  * Google 로그인 및 OAuth 콜백 처리에 대한 자동 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->