### PR TITLE
Design: 미션 보상 버튼 피드백 스타일 개선 (#80)

### DIFF
--- a/src/features/home/HomeMissionCard.tsx
+++ b/src/features/home/HomeMissionCard.tsx
@@ -77,7 +77,7 @@ export default function HomeMissionCard({ missions }: HomeMissionCardProps) {
                   <button
                     type="submit"
                     disabled={!isClaimable}
-                    className={`h-6 w-[56px] rounded-[7px] text-[10px] font-extrabold transition disabled:cursor-not-allowed ${buttonClassName}`}
+                    className={`h-6 w-[56px] cursor-pointer rounded-[7px] text-[10px] font-extrabold transition active:scale-95 disabled:cursor-not-allowed disabled:active:scale-100 ${buttonClassName}`}
                   >
                     {mission.isCompleted ? '완료' : '수령하기'}
                   </button>


### PR DESCRIPTION
# Pull Request

## 🎯 작업 내용

홈 미션 보상 버튼의 클릭 피드백 스타일을 개선했습니다.

## 📌 작업 배경

미션 보상 버튼 클릭 시 사용자에게 버튼이 눌렸다는 시각적 피드백이 부족했습니다.

## 🔨 구현 내용

#### Added (추가)

-

#### Changed (변경)

- 미션 보상 버튼에 `cursor-pointer`와 `active:scale-95` 스타일 추가
- disabled 상태에서는 active scale이 적용되지 않도록 `disabled:active:scale-100` 추가

#### Fixed (수정)

-

## 📸 결과물

- 커서 및 hover 적용
<img width="292" height="125" alt="스크린샷 2026-06-19 오후 4 57 38" src="https://github.com/user-attachments/assets/5b733b23-030d-40a5-a65c-f18ff5c57c25" />


## 🧪 테스트

- [x] `pnpm run typecheck`

## 💬 리뷰 요청사항

- 버튼 활성/비활성 상태의 시각적 피드백이 적절한지 확인 부탁드립니다.

## 🔗 관련 링크

- Closes #80