### PR TITLE
Feat: 추천 덱 복사 기능 및 토스트 알림 (#75)

### DIFF
--- a/src/features/chat/ChatbotModal.tsx
+++ b/src/features/chat/ChatbotModal.tsx
@@ -1,11 +1,10 @@
 'use client';
 
-import { useEffect, useRef, useState, useTransition } from 'react';
+import { useEffect, useReducer, useRef, useTransition } from 'react';
 
 import { typeLabelMap } from '@/app/(main)/(start)/build-deck/_constants/pokemon-type';
 import {
   analyzeEntryDeck,
-  copyCounterDeckToUser,
   loadEntryDeck,
   recommendCounterDeck,
   recommendTypeDeck,
@@ -13,6 +12,7 @@ import {
 } from '@/features/chat/actions';
 import type { DeckSuggestion } from '@/features/chat/actions';
 import AiDeckCard from '@/features/deck-recommendation/_components/AiDeckCard';
+import { useCopyDeck } from '@/features/deck-recommendation/hooks/use-copy-deck';
 import { cn } from '@/shared/lib/cn';
 import { useOverlayStore } from '@/shared/stores/overlay-store';
 import { PokemonType } from '@/shared/types/pokemon';
@@ -34,29 +34,80 @@ function parseRequestedFloor(text: string, currentFloor: number): number | null 
   return null;
 }
 
+type ChatbotState = {
+  input: string;
+  isTyping: boolean;
+  deckLoading: boolean;
+  entryReady: boolean;
+  entryHint: string;
+  pickerOpen: boolean;
+};
+
+type ChatbotAction =
+  | { type: 'SET_INPUT'; payload: string }
+  | { type: 'SET_PICKER_OPEN'; payload: boolean }
+  | { type: 'LOAD_DECK_SUCCESS'; payload: boolean }
+  | { type: 'LOAD_DECK_FAILURE'; payload: string }
+  | { type: 'START_SUGGESTION' }
+  | { type: 'START_SUBMIT' }
+  | { type: 'END_STREAM' }
+  | { type: 'ERROR_OCCURRED' };
+
+const initialState: ChatbotState = {
+  input: '',
+  isTyping: false,
+  deckLoading: true,
+  entryReady: false,
+  entryHint: '',
+  pickerOpen: false,
+};
+
+function chatbotReducer(state: ChatbotState, action: ChatbotAction): ChatbotState {
+  switch (action.type) {
+    case 'SET_INPUT':
+      return { ...state, input: action.payload };
+    case 'SET_PICKER_OPEN':
+      return { ...state, pickerOpen: action.payload };
+    case 'LOAD_DECK_SUCCESS':
+      return { ...state, deckLoading: false, entryReady: action.payload };
+    case 'LOAD_DECK_FAILURE':
+      return { ...state, deckLoading: false, entryReady: false, entryHint: action.payload };
+    case 'START_SUGGESTION':
+      return { ...state, pickerOpen: false };
+    case 'START_SUBMIT':
+      return { ...state, input: '', isTyping: true };
+    case 'END_STREAM':
+    case 'ERROR_OCCURRED':
+      return { ...state, isTyping: false };
+    default:
+      return state;
+  }
+}
+
 export default function ChatbotModal() {
   const { chatMessages } = useOverlayStore((state) => state);
   const currentFloor = useOverlayStore((state) => state.currentFloor ?? 1);
   const { closeChat, setChatMessages, updateLastAssistantMessage } = useOverlayStore((state) => state.actions);
 
-  const [input, setInput] = useState('');
-  const [isTyping, setIsTyping] = useState(false);
   const [isPending, startTransition] = useTransition();
-  const [deckLoading, setDeckLoading] = useState(true);
-  const [entryReady, setEntryReady] = useState(false);
-  const [entryHint, setEntryHint] = useState('');
-  const [pickerOpen, setPickerOpen] = useState(false);
+  const { copyDeck, isPending: copyPending } = useCopyDeck();
+
+  const [state, dispatch] = useReducer(chatbotReducer, initialState);
+  const { input, isTyping, deckLoading, entryReady, entryHint, pickerOpen } = state;
 
   const scrollRef = useRef<HTMLDivElement>(null);
+  const busy = isPending || isTyping || copyPending;
 
   // 챗봇이 열리면 등록 덱(pokedex_entries)을 미리 읽어 분석 칩 활성화 여부를 결정한다
   useEffect(() => {
     let active = true;
     loadEntryDeck().then((res) => {
       if (!active) return;
-      setEntryReady(res.ok);
-      if (!res.ok) setEntryHint(res.message);
-      setDeckLoading(false);
+      if (res.ok) {
+        dispatch({ type: 'LOAD_DECK_SUCCESS', payload: res.ok });
+      } else {
+        dispatch({ type: 'LOAD_DECK_FAILURE', payload: res.message });
+      }
     });
     return () => {
       active = false;
@@ -67,11 +118,9 @@ export default function ChatbotModal() {
     scrollRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [chatMessages]);
 
-  const busy = isPending || isTyping;
-
   function runSuggestion(userLabel: string, title: string, action: () => Promise<DeckSuggestion>) {
     if (busy) return;
-    setPickerOpen(false);
+    dispatch({ type: 'START_SUGGESTION' });
     setChatMessages((prev) => [...prev, { role: 'user', content: userLabel }]);
     startTransition(async () => {
       const res = await action();
@@ -85,16 +134,8 @@ export default function ChatbotModal() {
 
   function handleUseDeck(deck: ChatDeckSlot[]) {
     if (busy) return;
-    startTransition(async () => {
-      const res = await copyCounterDeckToUser(deck.map((d) => d.dexId));
-      setChatMessages((prev) => [
-        ...prev,
-        {
-          role: 'assistant',
-          content: res.success ? (res.message ?? '덱이 저장되었습니다.') : (res.error ?? '덱 저장에 실패했습니다.'),
-        },
-      ]);
-    });
+    // 복사 결과는 채팅 메시지가 아니라 토스트로 알린다 (useCopyDeck). 다른 채팅 로직은 그대로 유지.
+    copyDeck(deck.map((d) => d.dexId));
   }
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -109,7 +150,7 @@ export default function ChatbotModal() {
         { role: 'user', content: input },
         { role: 'assistant', content: `현재 ${currentFloor}층에서는 ${requestedFloor}층 공략을 도와드릴 수 없어요.` },
       ]);
-      setInput('');
+      dispatch({ type: 'SET_INPUT', payload: '' });
       return;
     }
 
@@ -119,9 +160,8 @@ export default function ChatbotModal() {
     const updatedMessages = [...chatMessages, userMessage];
 
     setChatMessages(updatedMessages);
-    setInput('');
-    setIsTyping(true);
 
+    dispatch({ type: 'START_SUBMIT' });
     setChatMessages((prev) => [...prev, { role: 'assistant', content: '' }]);
 
     try {
@@ -137,7 +177,7 @@ export default function ChatbotModal() {
         { role: 'assistant', content: '죄송합니다. 통신 오류가 발생했습니다. 다시 시도해 주세요.' },
       ]);
     } finally {
-      setIsTyping(false);
+      dispatch({ type: 'END_STREAM' });
     }
   };
 
@@ -216,7 +256,11 @@ export default function ChatbotModal() {
           <div className="flex flex-col gap-2">
             <div className="flex items-center justify-between">
               <span className="text-base-1 text-xs font-semibold">타입을 선택하세요</span>
-              <button type="button" onClick={() => setPickerOpen(false)} className="text-base-1 text-xs font-semibold">
+              <button
+                type="button"
+                onClick={() => dispatch({ type: 'SET_PICKER_OPEN', payload: false })}
+                className="text-base-1 text-xs font-semibold"
+              >
                 뒤로
               </button>
             </div>
@@ -250,7 +294,7 @@ export default function ChatbotModal() {
               >
                 이 층 카운터 덱
               </ChipButton>
-              <ChipButton disabled={busy} onClick={() => setPickerOpen(true)}>
+              <ChipButton disabled={busy} onClick={() => dispatch({ type: 'SET_PICKER_OPEN', payload: true })}>
                 특정 타입 덱
               </ChipButton>
               <ChipButton
@@ -272,7 +316,7 @@ export default function ChatbotModal() {
         <input
           type="text"
           value={input}
-          onChange={(e) => setInput(e.target.value)}
+          onChange={(e) => dispatch({ type: 'SET_INPUT', payload: e.target.value })}
           placeholder={busy ? 'AI가 생각하는 중입니다...' : '직접 입력해 물어보기'}
           disabled={busy}
           className="bg-base-2 text-base-0 placeholder:text-base-1 focus:border-primary focus:bg-base-3 flex-1 rounded-xl border border-transparent px-4 py-2.5 text-sm transition-all focus:outline-none"

--- a/src/features/chat/actions.ts
+++ b/src/features/chat/actions.ts
@@ -54,6 +54,36 @@ export async function copyCounterDeckToUser(dexIds: number[]) {
 
   if (authError || !user) return { success: false, error: '인증되지 않은 사용자입니다.' };
 
+  // 추천 덱은 dex_id(종)를 들고 있지만 deck_numbers는 instance_id(보유 개체)를 받는다.
+  // 보유 포켓몬 중 해당 dex_id를 가진 인스턴스를 찾아 dex_id -> instance_id로 변환한다.
+  const wantedDexIds = [...new Set(dexIds)].slice(0, DECK_SIZE);
+
+  const { data: owned, error: ownedError } = await supabase
+    .from('owned_pokemon')
+    .select('instance_id, dex_id, level')
+    .eq('user_id', user.id)
+    .in('dex_id', wantedDexIds);
+
+  if (ownedError) {
+    console.error('보유 포켓몬 조회 실패:', ownedError);
+    return { success: false, error: '보유 포켓몬을 불러오지 못했습니다.' };
+  }
+
+  // dex_id별로 레벨이 가장 높은 인스턴스 1개를 선택한다 (같은 인스턴스 중복 편성 방지).
+  const bestByDex = new Map<number, { instance_id: string; level: number }>();
+  for (const p of (owned ?? []) as { instance_id: string; dex_id: number; level: number }[]) {
+    const cur = bestByDex.get(p.dex_id);
+    if (!cur || p.level > cur.level) bestByDex.set(p.dex_id, { instance_id: p.instance_id, level: p.level });
+  }
+
+  const instanceIds = wantedDexIds
+    .map((dexId) => bestByDex.get(dexId)?.instance_id)
+    .filter((id): id is string => Boolean(id));
+
+  if (instanceIds.length === 0) {
+    return { success: false, error: '추천 덱에 넣을 수 있는 보유 포켓몬이 없습니다.' };
+  }
+
   const { data: deck, error: deckError } = await supabase
     .from('decks')
     .insert({ user_id: user.id, is_active: false })
@@ -65,10 +95,10 @@ export async function copyCounterDeckToUser(dexIds: number[]) {
     return { success: false, error: '덱 생성에 실패했습니다.' };
   }
 
-  const insertRows = dexIds.slice(0, 6).map((dexId, index) => ({
+  // position은 같은 덱 안에서 중복 불가 -> 0부터 순서대로 부여
+  const insertRows = instanceIds.map((instanceId, index) => ({
     deck_id: deck.id,
-    user_id: user.id,
-    dex_id: dexId,
+    instance_id: instanceId,
     position: index,
   }));
 
@@ -83,7 +113,17 @@ export async function copyCounterDeckToUser(dexIds: number[]) {
     }
     return { success: false, error: '덱의 포켓몬 상세 구성 저장에 실패했습니다.' };
   }
-  return { success: true, deckId: deck.id, message: '카운터 덱이 성공적으로 복사되었습니다.' };
+
+  // 복사한 덱을 활성 덱으로 전환한다 (유저당 활성 덱은 하나).
+  // 덱 편성(deck_numbers)이 끝난 뒤 전환해야 미완성 덱이 활성화되지 않는다.
+  await supabase.from('decks').update({ is_active: false }).eq('user_id', user.id).neq('id', deck.id);
+  const { error: activateError } = await supabase.from('decks').update({ is_active: true }).eq('id', deck.id);
+  if (activateError) {
+    // 복사 자체는 성공했으므로 활성화 실패는 로깅만 한다.
+    console.error('덱 활성화 실패:', activateError);
+  }
+
+  return { success: true, deckId: deck.id, message: '덱이 성공적으로 복사되었습니다.' };
 }
 
 export type EntryDeckPokemon = {

--- a/src/features/deck-recommendation/_components/AiDeckCard.tsx
+++ b/src/features/deck-recommendation/_components/AiDeckCard.tsx
@@ -4,6 +4,7 @@ import Image from 'next/image';
 
 import { cn } from '@/shared/lib/cn';
 import Tooltip from '@/shared/components/Tooltip';
+import { DeckCopyButton } from '@/shared/components/DeckCopyButton';
 
 const DEFAULT_SLOT_COUNT = 6;
 
@@ -86,14 +87,7 @@ export default function AiDeckCard({
         ))}
       </div>
 
-      <button
-        type="button"
-        onClick={onUseDeck}
-        disabled={disabled}
-        className="bg-primary text-base-3 flex h-8.5 w-full cursor-pointer items-center justify-center rounded-md px-5 text-sm leading-[1.4] font-bold tracking-tight transition-opacity disabled:cursor-not-allowed disabled:opacity-50"
-      >
-        덱 사용하기
-      </button>
+      <DeckCopyButton onUseDeck={onUseDeck ?? (() => {})} disabled={disabled} />
     </article>
   );
 }

--- a/src/features/deck-recommendation/hooks/use-copy-deck.ts
+++ b/src/features/deck-recommendation/hooks/use-copy-deck.ts
@@ -19,11 +19,16 @@ export function useCopyDeck(): UseCopyDeckResult {
   function copyDeck(dexIds: number[]) {
     if (isPending) return;
     startTransition(async () => {
-      const res = await copyCounterDeckToUser(dexIds);
-      if (res.success) {
-        toast.success(res.message ?? '덱이 복사되었습니다.');
-      } else {
-        toast.error(res.error ?? '덱 복사에 실패했습니다.');
+      try {
+        const res = await copyCounterDeckToUser(dexIds);
+        if (res.success) {
+          toast.success(res.message ?? '덱이 복사되었습니다.');
+        } else {
+          toast.error(res.error ?? '덱 복사에 실패했습니다.');
+        }
+      } catch (error) {
+        console.error(error);
+        toast.error('덱 복사 중 알 수 없는 오류가 발생했습니다. 관리자에게 문의하세요.');
       }
     });
   }

--- a/src/features/deck-recommendation/hooks/use-copy-deck.ts
+++ b/src/features/deck-recommendation/hooks/use-copy-deck.ts
@@ -1,0 +1,32 @@
+'use client';
+
+import { useTransition } from 'react';
+
+import { toast } from 'sonner';
+
+import { copyCounterDeckToUser } from '@/features/chat/actions';
+
+type UseCopyDeckResult = {
+  copyDeck: (dexIds: number[]) => void;
+  isPending: boolean;
+};
+
+// 추천 덱(dex_id 배열)을 유저 덱으로 복사하고 결과를 토스트로 알린다.
+// 챗봇·오늘의 추천 덱 양쪽에서 공용으로 사용한다.
+export function useCopyDeck(): UseCopyDeckResult {
+  const [isPending, startTransition] = useTransition();
+
+  function copyDeck(dexIds: number[]) {
+    if (isPending) return;
+    startTransition(async () => {
+      const res = await copyCounterDeckToUser(dexIds);
+      if (res.success) {
+        toast.success(res.message ?? '덱이 복사되었습니다.');
+      } else {
+        toast.error(res.error ?? '덱 복사에 실패했습니다.');
+      }
+    });
+  }
+
+  return { copyDeck, isPending };
+}

--- a/src/features/home/AiDeckRecommendContent.tsx
+++ b/src/features/home/AiDeckRecommendContent.tsx
@@ -6,6 +6,7 @@ import { RotateCcw } from 'lucide-react';
 
 import { recommendHomeDecks } from '@/features/deck-recommendation/actions/recommendDeck';
 import AiDeckCard from '@/features/deck-recommendation/_components/AiDeckCard';
+import { useCopyDeck } from '@/features/deck-recommendation/hooks/use-copy-deck';
 import type { RecommendResponse } from '@/features/deck-recommendation/model/schemas';
 import { cn } from '@/shared/lib/cn';
 
@@ -31,6 +32,7 @@ export default function AiDeckRecommendContent({ initialResults }: AiDeckRecomme
   const [results, setResults] = useState<[RecommendResponse, RecommendResponse]>(initialResults);
   const [isPending, startTransition] = useTransition();
   const [cooldown, setCooldown] = useState(0);
+  const { copyDeck, isPending: copyPending } = useCopyDeck();
 
   useEffect(() => {
     const remaining = getRemainingCooldown();
@@ -69,9 +71,23 @@ export default function AiDeckRecommendContent({ initialResults }: AiDeckRecomme
 
   return (
     <div className="mt-4 flex flex-col gap-2.5">
-      {first.ok && <AiDeckCard title={first.data.title} description={first.data.description} deck={first.data.deck} />}
+      {first.ok && (
+        <AiDeckCard
+          title={first.data.title}
+          description={first.data.description}
+          deck={first.data.deck}
+          onUseDeck={() => copyDeck(first.data.deck.map((d) => d.dexId))}
+          disabled={copyPending}
+        />
+      )}
       {second.ok && (
-        <AiDeckCard title={second.data.title} description={second.data.description} deck={second.data.deck} />
+        <AiDeckCard
+          title={second.data.title}
+          description={second.data.description}
+          deck={second.data.deck}
+          onUseDeck={() => copyDeck(second.data.deck.map((d) => d.dexId))}
+          disabled={copyPending}
+        />
       )}
       {allFailed && <p className="text-base-1 text-center text-sm">{first.message}</p>}
       <button

--- a/src/shared/components/DeckCopyButton.tsx
+++ b/src/shared/components/DeckCopyButton.tsx
@@ -1,0 +1,17 @@
+interface DeckCopyButtonProps {
+  onUseDeck: () => void;
+  disabled: boolean;
+}
+
+export function DeckCopyButton({ onUseDeck, disabled }: DeckCopyButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={onUseDeck}
+      disabled={disabled}
+      className="bg-primary text-base-3 flex h-8.5 w-full cursor-pointer items-center justify-center rounded-md px-5 text-sm leading-[1.4] font-bold tracking-tight transition-opacity disabled:cursor-not-allowed disabled:opacity-50"
+    >
+      덱 사용하기
+    </button>
+  );
+}


### PR DESCRIPTION
## 🎯 작업 내용

추천 덱의 "덱 사용하기" 버튼을 실제 동작하도록 구현하고, 복사 결과를 토스트로 알립니다. (챗봇 / 오늘의 추천 덱 공용)

## 📌 작업 배경

- "덱 사용하기" 버튼이 `deck_numbers` 저장 시 `PGRST204`(dex_id 컬럼 없음)로 실패하고 있었음
- 실제 스키마는 종(`dex_id`)이 아니라 보유 개체(`instance_id`, owned_pokemon FK) 기준으로 덱을 구성하는 1:N 구조였음
- "오늘의 추천 덱" 쪽 버튼은 `onUseDeck`이 연결되지 않아 클릭해도 동작하지 않던 상태

## 🔨 구현 내용

#### Added (추가)

- 덱 복사 공용 훅 `useCopyDeck` (`use-copy-deck.ts`) — 복사 + 결과 토스트(sonner) + 진행 중 상태
- 덱 사용 버튼 공용 컴포넌트 `DeckCopyButton`

#### Changed (변경)

- `copyCounterDeckToUser`: `dex_id` → `instance_id` 변환(보유 개체 중 레벨 높은 1마리 선택) 후 저장
- 복사한 덱을 활성 덱으로 전환(유저당 활성 덱 1개: 기존 비활성화 후 신규 활성화)
- `AiDeckCard`의 인라인 버튼을 `DeckCopyButton`으로 분리
- 챗봇: 복사 결과를 채팅 메시지 대신 토스트로 알림 (그 외 채팅 로직은 유지)
- 오늘의 추천 덱: 죽어있던 "덱 사용하기" 버튼에 `onUseDeck` 연결 + 진행 중 비활성

#### Fixed (수정)

- `deck_numbers` insert가 `dex_id` 컬럼 부재로 실패하던 `PGRST204` 오류 해결

## 📸 결과물

<!-- 스크린샷 첨부 예정 -->
- 실제로 db에 들어갑니다
<img width="1004" height="258" alt="스크린샷 2026-06-19 오후 6 10 14" src="https://github.com/user-attachments/assets/1680536a-8aa5-4325-9cf5-0d229f62031b" />


## 🧪 테스트

- [x] 로컬 테스트 완료 (typecheck / lint 통과)
- [x] 주요 시나리오 검증 (DB 확인: deck_numbers 슬롯 6개 생성, position 0~5, 활성 덱 1개 전환)

## 💬 리뷰 요청사항

- `instance_id` 선택 규칙: 같은 종 다수 보유 시 **레벨 높은 개체**를 선택하도록 했는데 정책 적절한지
- 활성 덱 전환(유저당 1개) 동작이 의도와 맞는지

## 🔗 관련 링크

- Closes #75

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **New Features**
  * 덱 복사 버튼 UI 컴포넌트 추가로 사용자 경험 개선
  * 덱 사용 시 토스트 알림을 통한 즉각적인 피드백 제공

* **Improvements**
  * 덱 추천 카드에서 덱 사용 기능 최적화
  * 덱 복사 진행 중 중복 실행 방지 기능 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->