### PR TITLE
Feat: 배틀 히스토리 패널 컴포넌트 구현

### DIFF
--- a/src/app/(main)/home/_constants/home.ts
+++ b/src/app/(main)/home/_constants/home.ts
@@ -1,6 +1,7 @@
 // 홈 화면 내비게이션, 액션 카드, 배너 데이터 상수
 
 import type {
+  BattleHistoryPokemon,
   HomeActionCardData,
   HomeBattleHistoryItem,
   HomeHeroCarouselItem,
@@ -78,6 +79,11 @@ export const homeheroCarouselItems: HomeHeroCarouselItem[] = [
 ];
 
 // 실제 데이터로 치환 필요
+const MOCK_DECK: BattleHistoryPokemon[] = Array.from({ length: 6 }, () => ({
+  artworkUrl: '/images/home/status/ball.svg',
+  koName: '포켓몬',
+}));
+
 export const homeBattleHistoryItem: HomeBattleHistoryItem[] = [
   {
     id: 'battle-1',
@@ -85,14 +91,7 @@ export const homeBattleHistoryItem: HomeBattleHistoryItem[] = [
     opponentName: '배틀광 재혁',
     floorName: '무한의 탑 13층',
     timeAgo: '1시간 전',
-    pokemonImageSrcs: [
-      '/images/home/status/ball.svg',
-      '/images/home/status/ball.svg',
-      '/images/home/status/ball.svg',
-      '/images/home/status/ball.svg',
-      '/images/home/status/ball.svg',
-      '/images/home/status/ball.svg',
-    ],
+    deckPokemons: [...MOCK_DECK],
   },
   {
     id: 'battle-2',
@@ -100,29 +99,7 @@ export const homeBattleHistoryItem: HomeBattleHistoryItem[] = [
     opponentName: '열혈 트레이너 강우',
     floorName: '무한의 탑 12층',
     timeAgo: '1시간 전',
-    pokemonImageSrcs: [
-      '/images/home/status/ball.svg',
-      '/images/home/status/ball.svg',
-      '/images/home/status/ball.svg',
-      '/images/home/status/ball.svg',
-      '/images/home/status/ball.svg',
-      '/images/home/status/ball.svg',
-    ],
-  },
-  {
-    id: 'battle-3',
-    result: 'WIN',
-    opponentName: 'anfdmf whgdkgksms wlgus',
-    floorName: '무한의 탑 13층',
-    timeAgo: '1시간 전',
-    pokemonImageSrcs: [
-      '/images/home/status/ball.svg',
-      '/images/home/status/ball.svg',
-      '/images/home/status/ball.svg',
-      '/images/home/status/ball.svg',
-      '/images/home/status/ball.svg',
-      '/images/home/status/ball.svg',
-    ],
+    deckPokemons: [...MOCK_DECK],
   },
 ];
 

--- a/src/app/(main)/home/_types/home.ts
+++ b/src/app/(main)/home/_types/home.ts
@@ -36,13 +36,18 @@ export interface HomeActionCardData {
   silhouetteClassName?: string;
 }
 
+export interface BattleHistoryPokemon {
+  artworkUrl: string;
+  koName: string;
+}
+
 export interface HomeBattleHistoryItem {
   id: string;
   result: 'WIN' | 'DEFEAT';
   opponentName: string;
   floorName: string;
   timeAgo: string;
-  pokemonImageSrcs: string[];
+  deckPokemons: BattleHistoryPokemon[];
 }
 
 export interface HomeNewsItem {

--- a/src/app/(main)/home/page.tsx
+++ b/src/app/(main)/home/page.tsx
@@ -1,4 +1,5 @@
 import AiDeckRecommendPanel from '@/features/home/AiDeckRecommendPanel';
+import BattleHistoryPanel from '@/features/home/BattleHistoryPanel';
 import HomeActionCards from '@/features/home/HomeActionCards';
 import HomeBanner from '@/features/home/HomeBanner';
 import HomeMissionCard from '@/features/home/HomeMissionCard';
@@ -37,11 +38,8 @@ export default async function HomePage() {
               <div data-tour-id="home-mission">
                 <HomeMissionCard missions={dailyMissions} />
               </div>
-              <div
-                data-tour-id="home-history"
-                className="h-[280px] rounded-[20px] bg-[var(--color-base-3)] p-5 shadow-[0_10px_30px_rgba(0,0,0,0.06)]"
-              >
-                배틀 히스토리 영역
+              <div data-tour-id="home-history">
+                <BattleHistoryPanel />
               </div>
             </div>
 

--- a/src/features/home/BattleHistoryPanel.tsx
+++ b/src/features/home/BattleHistoryPanel.tsx
@@ -1,0 +1,96 @@
+import Image from 'next/image';
+
+import { homeBattleHistoryItem } from '@/app/(main)/home/_constants/home';
+import type { BattleHistoryPokemon, HomeBattleHistoryItem } from '@/app/(main)/home/_types/home';
+import Tooltip from '@/shared/components/Tooltip';
+import { cn } from '@/shared/lib/cn';
+
+function BattlePokemonSlot({ artworkUrl, koName }: BattleHistoryPokemon) {
+  if (!artworkUrl) {
+    return <div aria-hidden className="size-[30px] shrink-0 rounded-[3px] border border-[#d9d9d9]" />;
+  }
+
+  return (
+    <div className="group relative shrink-0">
+      <Tooltip
+        text={koName}
+        className="pointer-events-none invisible absolute bottom-[calc(100%+6px)] left-1/2 z-10 w-max -translate-x-1/2 group-hover:visible"
+      />
+      <div className="size-[30px] overflow-hidden rounded-[3px] border border-[#d9d9d9]">
+        <Image src={artworkUrl} alt={koName} width={30} height={30} className="h-full w-full object-contain" />
+      </div>
+    </div>
+  );
+}
+
+function BattleHistoryRow({ item }: { item: HomeBattleHistoryItem }) {
+  const isWin = item.result === 'WIN';
+
+  return (
+    <div className="flex w-full">
+      <div
+        className={cn(
+          'flex max-h-15.5 w-[33px] shrink-0 items-center justify-center rounded-tl-lg rounded-bl-lg',
+          isWin ? 'bg-[#e6f1ff]' : 'bg-[#ffeded]',
+        )}
+      >
+        <span
+          className={cn(
+            '-rotate-90 text-[13px] leading-[1.4] font-bold tracking-[-0.325px] whitespace-nowrap',
+            isWin ? 'text-[#4795ff]' : 'text-[#ff4747]',
+          )}
+        >
+          {item.result}
+        </span>
+      </div>
+
+      <div className="flex flex-1 items-center gap-3 rounded-tr-lg rounded-br-lg border-t border-r border-b border-[#d9d9d9] py-2 pr-[15px] pl-[10px]">
+        <div className="flex w-[190px] shrink-0 items-center gap-[10px]">
+          <div className="relative size-11 shrink-0 opacity-20">
+            <Image src="/images/home/action/battlesymbol.svg" alt="" fill className="object-contain" />
+          </div>
+          <div className="flex min-w-0 flex-col gap-[5px]">
+            <p className="truncate text-[15px] leading-[1.4] font-semibold tracking-[-0.375px]">
+              <span className="text-base-1">VS</span>
+              <span className="text-base-0"> {item.opponentName}</span>
+            </p>
+            <p className="text-base-1 text-[13px] leading-[1.4] tracking-[-0.325px]">{item.floorName}</p>
+          </div>
+        </div>
+
+        <div className="flex flex-1 justify-center gap-[6px]">
+          {item.deckPokemons.map((pokemon, i) => (
+            <BattlePokemonSlot key={i} artworkUrl={pokemon.artworkUrl} koName={pokemon.koName} />
+          ))}
+        </div>
+
+        <p className="w-10 shrink-0 text-right text-[11px] leading-[1.4] tracking-[-0.275px] text-[#aaa]">
+          {item.timeAgo}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export default function BattleHistoryPanel() {
+  return (
+    <section className="bg-base-3 min-h-[280px] overflow-clip rounded-[20px] px-[25px] py-5 shadow-[0_10px_30px_rgba(0,0,0,0.06)]">
+      <div className="flex items-center justify-between">
+        <h2 className="text-base-0 text-base font-bold tracking-[-0.4px]">배틀 히스토리</h2>
+        <p className="text-base-1 text-[12px] tracking-[-0.3px]">최신 3건이 표시됩니다.</p>
+      </div>
+
+      {homeBattleHistoryItem.length === 0 ? (
+        <div className="mt-5 flex min-h-[200px] items-center justify-center">
+          <p className="text-base-1 text-sm">아직 배틀 기록이 없습니다.</p>
+        </div>
+      ) : (
+        <div className="mt-3.5 flex flex-col gap-[10px]">
+          {homeBattleHistoryItem.map((item) => (
+            <BattleHistoryRow key={item.id} item={item} />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}


### PR DESCRIPTION
## 🎯 작업 내용

홈 화면 배틀 히스토리 섹션을 구현합니다.

## 📌 작업 배경

홈 화면의 배틀 히스토리 영역이 플레이스홀더 상태였고, 이를 실제 UI로 구현했습니다.
현재는 mock 데이터를 사용 중이며, 추후 배틀 기능이 완성되면 data source만 교체하면 됩니다.

## 🔨 구현 내용

#### Added (추가)

- `BattleHistoryPanel` 컴포넌트 구현 (WIN/DEFEAT 배지, 덱 슬롯 hover 툴팁, 빈 상태 에러 처리)
- `BattleHistoryPokemon` 타입 추가

#### Changed (변경)

- `HomeBattleHistoryItem.pokemonImageSrcs: string[]` → `deckPokemons: BattleHistoryPokemon[]` 타입 변경
- 배틀 히스토리 mock 데이터 2개(DEFEAT/WIN)로 정리 및 구조 변경
- 홈 페이지 플레이스홀더 → `BattleHistoryPanel` 연결

#### Fixed (수정)

-

## 📸 결과물

<!-- 스크린샷 추가 예정 -->
> 결과 화면
<img width="622" height="272" alt="스크린샷 2026-06-20 오후 10 53 53" src="https://github.com/user-attachments/assets/72afc1dd-db97-4499-9d91-a641af46b42b" />

> 간격은 '오늘의 미션'과 최대한 맞춰놨습니다.
<img width="954" height="285" alt="스크린샷 2026-06-20 오후 10 54 36" src="https://github.com/user-attachments/assets/8392588e-2fd7-4a8c-9241-33ca69dae689" />

## 🧪 테스트

- [x] 로컬 테스트 완료
- [x] 주요 시나리오 검증

## 💬 리뷰 요청사항

- 현재 mock 데이터 기반으로 동작합니다. 배틀 기능 완성 시 `BattleHistoryPanel`을 async 서버 컴포넌트로 전환하고 Supabase API 호출로 교체하면 됩니다. UI 컴포넌트(`BattleHistoryRow`, `BattlePokemonSlot`)는 그대로 재사용 가능합니다.

## 🔗 관련 링크

- Closes #84