### PR TITLE
Fix: 챗봇 LLM Ollama → Gemini 전환 및 비스트리밍 응답 (#62)

### DIFF
--- a/src/features/chat/ChatbotModal.tsx
+++ b/src/features/chat/ChatbotModal.tsx
@@ -5,10 +5,10 @@ import { useEffect, useReducer, useRef, useTransition } from 'react';
 import { typeLabelMap } from '@/app/(main)/(start)/build-deck/_constants/pokemon-type';
 import {
   analyzeEntryDeck,
+  generateChatResponse,
   loadEntryDeck,
   recommendCounterDeck,
   recommendTypeDeck,
-  streamChatResponse,
 } from '@/features/chat/actions';
 import type { DeckSuggestion } from '@/features/chat/actions';
 import AiDeckCard from '@/features/deck-recommendation/_components/AiDeckCard';
@@ -165,11 +165,8 @@ export default function ChatbotModal() {
     setChatMessages((prev) => [...prev, { role: 'assistant', content: '' }]);
 
     try {
-      const textStream = await streamChatResponse(updatedMessages, targetFloor);
-
-      for await (const textDelta of textStream) {
-        updateLastAssistantMessage(textDelta);
-      }
+      const res = await generateChatResponse(updatedMessages, targetFloor);
+      updateLastAssistantMessage(res.ok ? res.content : res.message);
     } catch (err) {
       console.error(err);
       setChatMessages((prev) => [

--- a/src/features/chat/actions.ts
+++ b/src/features/chat/actions.ts
@@ -1,7 +1,7 @@
 'use server';
 
-import { generateText, streamText } from 'ai';
-import { createOllama } from 'ollama-ai-provider-v2';
+import { google } from '@ai-sdk/google';
+import { generateText } from 'ai';
 
 import { typeLabelMap } from '@/app/(main)/(start)/build-deck/_constants/pokemon-type';
 import { filterByType, filterTowerCounter } from '@/features/deck-recommendation/lib/rule-engine';
@@ -14,15 +14,11 @@ import type { ChatMessage } from '@/shared/stores/overlay-store';
 
 import { TYPE_CHART } from '../../../data/type-chart';
 
-const LLM_BASE_URL = process.env.LLM_BASE_URL ?? 'http://localhost:11434/api';
-const LLM_CHAT_MODEL = process.env.LLM_CHAT_MODEL ?? 'exaone3.5:7.8b';
-const LLM_API_KEY = process.env.LLM_API_KEY;
+// 챗봇 LLM은 Gemini를 사용한다. 키는 GOOGLE_GENERATIVE_AI_API_KEY 환경변수에서 자동 주입된다.
+const LLM_CHAT_MODEL = process.env.LLM_CHAT_MODEL ?? 'gemini-2.5-flash';
 
-const llm = createOllama({
-  baseURL: LLM_BASE_URL,
-  // 원격 Ollama(EC2)는 프록시에서 Bearer 토큰을 검증한다. 로컬은 키가 없어 헤더 미전송.
-  headers: LLM_API_KEY ? { Authorization: `Bearer ${LLM_API_KEY}` } : undefined,
-});
+// gemini-2.5-flash의 추론(thinking) 토큰을 끈다. 단답형 공략 응답에 불필요한 지연·비용을 줄인다.
+const NO_THINKING = { google: { thinkingConfig: { thinkingBudget: 0 } } } as const;
 
 type EnemySpecies = {
   ko_name: string;
@@ -239,7 +235,12 @@ const EXPLAIN_SYSTEM_PROMPT = `너는 PODECK 무한의 탑 공략 조력자다. 
 // 확정된 덱에 대한 짧은 설명만 LLM으로 생성한다 (덱 선정 자체는 결정론)
 async function explainDeck(prompt: string): Promise<string> {
   try {
-    const { text } = await generateText({ model: llm(LLM_CHAT_MODEL), system: EXPLAIN_SYSTEM_PROMPT, prompt });
+    const { text } = await generateText({
+      model: google(LLM_CHAT_MODEL),
+      system: EXPLAIN_SYSTEM_PROMPT,
+      prompt,
+      providerOptions: NO_THINKING,
+    });
     return text
       .replace(/\*\*/g, '')
       .replace(/([.!?])\s+/g, '$1\n')
@@ -340,8 +341,12 @@ export async function analyzeEntryDeck(currentFloor: number): Promise<DeckSugges
   return { ok: true, deck: toDeckSlots(roster), explanation: lines.join('\n') };
 }
 
-// 채팅 스트리밍 응답 생성
-export async function streamChatResponse(messages: ChatMessage[], currentFloor: number) {
+export type ChatResponse = { ok: true; content: string } | { ok: false; message: string };
+
+// 채팅 응답 생성(비스트리밍).
+// textStream(async iterable)을 Server Action 경계 밖으로 반환하면 무한 pending이 발생하므로
+// 전체 응답을 받아 한 번에 돌려준다.
+export async function generateChatResponse(messages: ChatMessage[], currentFloor: number): Promise<ChatResponse> {
   const supabase = await createClient();
 
   // 적 정보는 DB(tower_floors.pokemon_pool)의 dex ID를 기준으로 species를 조회한다
@@ -385,14 +390,20 @@ ${enemyContext}
 - 모든 문장을 완벽한 한국어로만 써라. 영어 단어(HP, Burn 등)는 '체력', '화상'처럼 한글로 바꾸고, 포켓몬 타입도 반드시 한글(불꽃, 물, 노말 등)로 표기해라.
 - 마크다운 기호(**, #)나 이모지를 절대 쓰지 말고 담백한 글자로만 출력해라.`;
 
-  const result = await streamText({
-    model: llm(LLM_CHAT_MODEL),
-    system: CHAT_SYSTEM_PROMPT,
-    messages: messages.map((msg) => ({
-      role: msg.role,
-      content: msg.content,
-    })),
-  });
+  try {
+    const { text } = await generateText({
+      model: google(LLM_CHAT_MODEL),
+      system: CHAT_SYSTEM_PROMPT,
+      messages: messages.map((msg) => ({
+        role: msg.role,
+        content: msg.content,
+      })),
+      providerOptions: NO_THINKING,
+    });
 
-  return result.textStream;
+    return { ok: true, content: text.replace(/\*\*/g, '').trim() };
+  } catch (error) {
+    console.error('채팅 응답 생성 실패:', error);
+    return { ok: false, message: '죄송합니다. 통신 오류가 발생했습니다. 다시 시도해 주세요.' };
+  }
 }


### PR DESCRIPTION
## 🎯 작업 내용

배포 환경에서 AI 챗봇이 무응답이던 문제를 해결하기 위해 챗봇 LLM을 로컬 Ollama에서 Gemini로 전환하고, 응답 방식을 비스트리밍으로 변경했습니다.

## 📌 작업 배경

- 챗봇 `actions.ts`가 EC2 원격 Ollama 실험 커밋(`07774a62`)의 영향으로 `localhost:11434` Ollama를 바라보고 있었습니다.
- Vercel 배포 환경에는 로컬 Ollama 서버가 없어 챗봇이 무응답 상태였습니다.
- 환경변수·패키지(`@ai-sdk/google`, `GOOGLE_GENERATIVE_AI_API_KEY`)는 이미 Gemini로 준비되어 있었으나, 코드의 최종 Gemini 전환이 미커밋 상태로 유실되어 있었습니다.

## 🔨 구현 내용

### Changed
- 챗봇 LLM 프로바이더를 `ollama-ai-provider-v2`(`createOllama`)에서 `@ai-sdk/google`(`gemini-2.5-flash`)로 교체
- `LLM_BASE_URL` / `LLM_API_KEY`(원격 Ollama Bearer 인증) 의존 제거
- `streamChatResponse`(textStream 반환) → `generateChatResponse`(비스트리밍 `ChatResponse` 반환)로 변경
- `ChatbotModal`의 스트림 소비 루프(`for await`)를 단일 응답 처리로 변경

### Fixed
- 배포 환경에서 로컬 Ollama 부재로 챗봇이 무응답이던 문제
- `textStream`(async iterable)을 Server Action 경계 밖으로 반환할 때 발생하던 무한 pending 문제

### Added
- `thinkingBudget: 0`(`NO_THINKING`) 적용 — 단답형 공략 응답에 불필요한 추론 토큰 비용·지연 차단

## 🧪 테스트

- [x] `tsc --noEmit` 타입 체크 통과 (chat/actions.ts, chat/ChatbotModal.tsx)
- [x] `eslint` 통과
- [ ] Vercel 환경변수 `GOOGLE_GENERATIVE_AI_API_KEY` 등록 여부 확인 후 배포 동작 검증

## 💬 리뷰 요청사항

- Vercel 프로젝트 환경변수에 `GOOGLE_GENERATIVE_AI_API_KEY`(필요 시 `LLM_CHAT_MODEL`)가 등록되어 있어야 정상 동작합니다.

## 🔗 Closes

#62


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **기능 개선**
  * 채팅 응답 생성 방식을 개선하여 더욱 안정적인 응답 처리 제공
  * AI 모델을 Google Gemini로 업그레이드하여 향상된 성능 제공

<!-- end of auto-generated comment: release notes by coderabbit.ai -->